### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/core/rss.py
+++ b/core/rss.py
@@ -9,7 +9,10 @@ class RSS:
             self.cache_dir = cache_dir
       
         os.makedirs(self.cache_dir, exist_ok=True)
-        self.rss_file=f"{self.cache_dir}/{name}.xml"
+        normalized_path = os.path.normpath(f"{self.cache_dir}/{name}.xml")
+        if not normalized_path.startswith(os.path.abspath(self.cache_dir)):
+            raise ValueError("Invalid file path: Path traversal detected.")
+        self.rss_file = normalized_path
         pass
     def serialize_datetime(self,obj):
         if isinstance(obj, datetime):


### PR DESCRIPTION
Potential fix for [https://github.com/rachelos/we-mp-rss/security/code-scanning/8](https://github.com/rachelos/we-mp-rss/security/code-scanning/8)

To fix the issue, we need to ensure that the `rss_file` path is validated and constrained to a safe directory. This can be achieved by normalizing the path using `os.path.normpath` and verifying that it resides within the intended `cache_dir`. If the normalized path does not start with `cache_dir`, an exception should be raised to prevent unauthorized access.

**Steps to fix:**
1. Normalize the constructed `rss_file` path using `os.path.normpath`.
2. Verify that the normalized path starts with the `cache_dir` to ensure it is within the allowed directory.
3. Raise an exception if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
