### PR TITLE
feat: web_ui,添加消息任务，选择公众号时直接加载更多公众号

### DIFF
--- a/web_ui/src/api/subscription.ts
+++ b/web_ui/src/api/subscription.ts
@@ -32,6 +32,8 @@ export interface MpItem {
   mp_id: string
   mp_name: string
   avatar: string
+  id?: string
+  mp_cover?: string
 }
 
 export interface MpSearchResult {

--- a/web_ui/src/types/messageTask.ts
+++ b/web_ui/src/types/messageTask.ts
@@ -1,26 +1,34 @@
+import type { MpItem } from './subscription'
+
 export interface MessageTask {
   id: number
+  name: string
+  message_type: number
   message_template: string
   web_hook_url: string
-  mps_id: any // JSON类型
+  mps_id: string // JSON字符串，解析后为 MpItem[]
   status: number
-  cron_exp?: string
+  cron_exp: string
   created_at: string
   updated_at: string
 }
 
 export interface MessageTaskCreate {
+  name: string
+  message_type: number
   message_template: string
   web_hook_url: string
-  mps_id: any
-  status?: number
-  cron_exp?: string
+  mps_id: MpItem[]
+  status: number
+  cron_exp: string
 }
 
 export interface MessageTaskUpdate {
+  name?: string
+  message_type?: number
   message_template?: string
   web_hook_url?: string
-  mps_id?: any
+  mps_id?: MpItem[]
   status?: number
   cron_exp?: string
 }

--- a/web_ui/src/types/subscription.ts
+++ b/web_ui/src/types/subscription.ts
@@ -1,0 +1,5 @@
+export interface MpItem {
+  id: string
+  mp_name: string
+  mp_cover: string
+} 

--- a/web_ui/src/views/MessageTaskForm.vue
+++ b/web_ui/src/views/MessageTaskForm.vue
@@ -4,6 +4,7 @@ const formRef = ref()
 import { useRoute, useRouter } from 'vue-router'
 import { getMessageTask, createMessageTask, updateMessageTask } from '@/api/messageTask'
 import type { MessageTask, MessageTaskCreate } from '@/types/messageTask'
+import type { MpItem } from '@/types/subscription'
 import cronExpressionPicker from '@/components/cronExpressionPicker.vue'
 import MpMultiSelect from '@/components/MpMultiSelect.vue'
 import { Message } from '@arco-design/web-vue'
@@ -23,7 +24,7 @@ const formData = ref<MessageTaskCreate>({
   message_type: 0,
   message_template: '',
   web_hook_url: '',
-  mps_id: [],
+  mps_id: [] as MpItem[],
   status: 1,
   cron_exp: '*/5 * * * *'
 })
@@ -37,7 +38,7 @@ const fetchTaskDetail = async (id: string) => {
       message_type: res.message_type,
       message_template: res.message_template,
       web_hook_url: res.web_hook_url,
-      mps_id: JSON.parse(res.mps_id||[]),
+      mps_id: res.mps_id ? JSON.parse(res.mps_id) : [],
       status: res.status,
       cron_exp: res.cron_exp
     }
@@ -46,7 +47,7 @@ const fetchTaskDetail = async (id: string) => {
       if (cronPickerRef.value) {
         cronPickerRef.value.parseExpression(formData.value.cron_exp)
       }
-      if (mpSelectorRef.value) {
+      if (mpSelectorRef.value && formData.value.mps_id.length > 0) {
         mpSelectorRef.value.parseSelected(formData.value.mps_id)
       }
     })


### PR DESCRIPTION
**添加消息任务** 选择目标公众号时，由于默认加载 10 条记录

超过 10 条筛选的时候会存在操作不便捷的问题

![image](https://github.com/user-attachments/assets/a7473ec0-a5be-45f4-9a75-4329bcf93530)

弹框中增加了一个 **加载更多**  按钮，可以 load 下一页内容