### PR TITLE
1.4.6 修正CSV导出功能，保留BOM头

### DIFF
--- a/web_ui/src/api/export.ts
+++ b/web_ui/src/api/export.ts
@@ -9,13 +9,11 @@ export const ExportOPML = () => {
 }
 
 export const ExportMPS = () => {
-  return http.get<{code: number, data: string}>('/wx/export/mps/export', {
-    params: {
-      limit: 1000,
-      offset: 0
-    }
-  })
-}
+  return http.get('/wx/export/mps/export', {
+    params: { limit: 1000, offset: 0 },
+    responseType: 'blob',
+  });
+};
 
 export const ImportMPS = (formData) => {
   return http.post<{code: number, data: string}>('/wx/export/mps/import', formData, {

--- a/web_ui/src/views/article/ArticleListDesktop.vue
+++ b/web_ui/src/views/article/ArticleListDesktop.vue
@@ -364,8 +364,11 @@ const exportOPML = async () => {
 };
 const exportMPS = async () => {
   try {
-    const response = await ExportMPS();
-    const blob = new Blob([response], { type: 'application/csv' });
+    const res = await ExportMPS();
+    const data = (res as any).data ?? res;
+    const blob = data instanceof Blob
+      ? data
+      : new Blob([data], { type: 'text/csv;charset=utf-8' });
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -374,7 +377,7 @@ const exportMPS = async () => {
     a.click();
     window.URL.revokeObjectURL(url);
     document.body.removeChild(a);
-  } catch (error) {
+  } catch (error: any) {
     Message.error(error?.message || '导出公众号失败');
   }
 };


### PR DESCRIPTION
**fix:** 修正CSV导出功能，保留BOM头，使excle正确识别编码

**原因：** Axios 默认按文本/JSON 解析导致 BOM 被吞
**方法：** 接口设置 responseType:'blob'，前端以二进制 Blob 下载
[**原issue**](https://github.com/rachelos/we-mp-rss/issues/155)

> 感谢感谢！！！大佬的项目太好用啦，之前用[wewe-rss](https://github.com/cooderl/wewe-rss)老是更新失败，修了半天发现曲线救国还不如直接用您的项目。重点是！大佬还在每天高强度更新🎉🎉🎉，下面是一点点小优化~

<img width="988" height="721" alt="image" src="https://github.com/user-attachments/assets/09f96c4f-2dbf-4492-9dde-f6cd9188e3f7" />

