### PR TITLE
1.4.6 支持可配置的单次更新页数 page_limit

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -158,6 +158,7 @@ http://localhost:3000
 | `PORT` | `8001` | API服务端口 |
 | `DEBUG` | `False` | 调试模式 |
 | `MAX_PAGE` | `5` | 最大采集页数 |
+| `PAGE_LIMIT` | `1` | 最大更新页数 |
 | `RSS_BASE_URL` | 空 | RSS域名地址 |
 | `RSS_LOCAL` | `False` | 是否为本地RSS链接 |
 | `RSS_TITLE` | 空 | RSS标题 |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -45,6 +45,8 @@ debug: ${DEBUG:-False}
 
 #最大页数 第一次添加 采集的页数默认5页
 max_page: ${MAX_PAGE:-5}
+#更新页数 之后的更新 采集的页数默认1页
+page_limit: ${PAGE_LIMIT:-1}
 
 rss:
   #RSS域名地址：如https://www.xxx.com/


### PR DESCRIPTION
**原因：** 原有的每次消息任务更新页数硬编码为 1，添加自定义参数加页防止遗漏
**方法：** 在 fetch_all_article 与 do_job 中从 cfg['page_limit'] 读取（缺省 1），并以 MaxPage 传给 wx.get_Articles；不改函数签名，保持兼容
**配置：** 新增 page_limit: ${PAGE_LIMIT:-1}

> 感谢感谢！！！大佬的项目太好用啦，之前用[wewe-rss](https://github.com/cooderl/wewe-rss)老是更新失败，修了半天发现曲线救国还不如直接用您的项目。重点是！大佬还在每天高强度更新🎉🎉🎉，上面是又一点点小优化~