### PR TITLE
1.4.6 增加下拉栏三角图标的动画

### DIFF
--- a/web_ui/src/views/article/ArticleListDesktop.vue
+++ b/web_ui/src/views/article/ArticleListDesktop.vue
@@ -703,6 +703,15 @@ const exportArticles = () => {
   z-index: 9999 !important;
   /* 确保抽屉在其他内容之上 */
 }
+
+:deep(.arco-btn .arco-icon-down) {
+  transition: transform 0.2s ease-in-out;
+}
+
+:deep(.arco-dropdown-open .arco-icon-down) {
+  transform: rotate(180deg);
+}
+
 </style>
 <style>
 #article-model img {


### PR DESCRIPTION
**内容：** 🌸漂亮的小动画~🌸
**方法：** 加了个 CSS 全局作用于 `.arco-dropdown-open` 类

![PixPin_2025-08-28_11-13-20](https://github.com/user-attachments/assets/fb1ad07a-b7b4-438b-87ed-a9d0656d2874)

> 感谢感谢！！！大佬的项目太好用啦，之前用[wewe-rss](https://github.com/cooderl/wewe-rss)老是更新失败，修了半天发现曲线救国还不如直接用您的项目。重点是！大佬还在每天高强度更新🎉🎉🎉，上面是又一点点小优化~