### PR TITLE
Potential fix for code scanning alert no. 141: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,4 +1,6 @@
 name: Docker Image Publish
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rachelos/we-mp-rss/security/code-scanning/141](https://github.com/rachelos/we-mp-rss/security/code-scanning/141)

The correct way to fix this issue is to add an explicit `permissions` block to the workflow or the relevant job. Because there is only one job (`build-and-push`), you can add the permissions block either at the top level of the workflow (making it apply to all jobs by default) or at the job level. The minimal permission needed for common Docker (GHCR) publishing and checkout workflows is typically `contents: read`. If the workflow needs to publish to GHCR (GitHub Container Registry) only, `contents: read` is enough for GITHUB_TOKEN. Add the following block after the `name` property in the workflow YAML:

```yaml
permissions:
  contents: read
```

Make this change at the root level in `.github/workflows/docker-publish.yaml`, directly after the workflow name and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
