### PR TITLE
fix: add lib configuration to support async/await and dynamic imports

### DIFF
--- a/web_ui/tsconfig.json
+++ b/web_ui/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "lib": ["ES2020", "DOM"],
     "paths": {
       "@/*": ["src/*"]
     }


### PR DESCRIPTION
## 修改描述

修复上个 PR（https://github.com/rachelos/we-mp-rss/pull/243） 中浏览器通知功能未能生效的问题。

## 问题原因

新增的浏览器通知功能（`browserNotification.ts`）使用了 async/await 和动态 import()，但 TypeScript 编译配置缺少相应的库声明，导致编译错误。

## 解决方案

更新 `web_ui/tsconfig.json`，在 `compilerOptions` 中添加：
```json
"lib": ["ES2020", "DOM"]