### PR TITLE
修复桌面窄宽度下文章列表标题显示不全的问题

### DIFF
--- a/web_ui/src/views/article/ArticleListDesktop.vue
+++ b/web_ui/src/views/article/ArticleListDesktop.vue
@@ -1,5 +1,5 @@
 <template>
-  <a-spin class="article-list-spin" :style="{ display: 'block', width: '100%' }" :loading="fullLoading" tip="正在刷新..." size="large">
+  <a-spin :style="{ display: 'block', width: '100%' }" :loading="fullLoading" tip="正在刷新..." size="large">
     <a-layout class="article-list">
       
       <a-layout-sider
@@ -1135,15 +1135,6 @@ const toggleFavoriteStatus = async (record: any) => {
   /* height: calc(100vh - 186px); */
   width: 100%;
   min-width: 0;
-}
-
-:deep(.article-list-spin.arco-spin) {
-  display: block;
-  width: 100%;
-}
-
-:deep(.article-list-spin .arco-spin-children) {
-  width: 100%;
 }
 
 .a-layout-sider {


### PR DESCRIPTION
## 背景

我这边在桌面端看文章列表时，发现一个比较影响使用的问题：

- 浏览器宽度缩小到桌面临界尺寸时（其实发现这个问题是在 iPad 这样的 4:3 屏幕上，正好不宽不窄，很尴尬），左侧公众号栏会明显挤压右侧内容区
- 文章标题这一列会被压到只剩几个字，基本没法靠标题快速判断文章内容
- 这时候最关键的信息反而最难看清，阅读和筛选都比较难受

<img width="1339" height="1040" alt="小尺寸页面存在的问题" src="https://github.com/user-attachments/assets/0da5c20e-86a1-40cf-971a-128802586e1e" />


## 这次 PR 解决什么

这次只聚焦前端界面本身，目标很明确：

1. 让桌面窄宽度下的文章标题不再被挤得几乎不可读
2. 给左侧栏一个更顺手的折叠入口，把空间尽量让给内容区
3. 在不切到移动端的情况下，保留桌面端表格的可读性

https://github.com/user-attachments/assets/20d0c2a2-9ffd-4ad9-9716-136cb261e923


## 具体改动

- `web_ui/src/views/article/ArticleListDesktop.vue`
  - 增加左侧栏折叠/展开能力
  - 将折叠按钮放到标题左侧，交互更接近常见桌面应用侧栏开关
  - 调整内容区布局和宽度计算，避免外层容器把表格撑坏
  - 恢复表格横向滚动能力，避免标题列被硬挤压

## 验证点

- 桌面端较窄宽度下，文章标题可读性明显改善
- 折叠左侧栏后，右侧内容区会变宽
- 表格在窄宽度下可以横向滚动，不再把标题压缩到只剩几个字
