### PR TITLE
fix: 修复公众号列表切换启停后分页数量异常

### DIFF
--- a/web_ui/src/views/article/ArticleListDesktop.vue
+++ b/web_ui/src/views/article/ArticleListDesktop.vue
@@ -960,11 +960,7 @@ const toggleMpStatus = async (mpId: string, newStatus: number) => {
   try {
     await toggleMpStatusApi(mpId, newStatus);
     Message.success(newStatus === 0 ? '公众号已禁用' : '公众号已启用');
-    // 更新本地数据
-    const index = mpList.value.findIndex(item => item.id === mpId);
-    if (index !== -1) {
-      mpList.value[index].status = newStatus;
-    }
+    await fetchMpList()
   } catch (error) {
     console.error('更新公众号状态失败:', error);
     Message.error('更新公众号状态失败');


### PR DESCRIPTION
 ## 问题
  公众号列表页在点击“停用/启用”后，当前页展示数量会立即减少，例如每页 10 条会变成 9 条，再停用一个会变成 8 条。
  列表只有在后续再次刷新后才会恢复正常，导致分页展示与实际数据不一致。

  ## 原因
  - 前端切换公众号状态后，仅更新了本地列表项的 `status`，没有重新拉取当前分页数据。
  - 在“启用/停用”筛选场景下，状态变化后的记录会立即不再满足当前筛选条件，但当前页没有重新补位。
  - 后端公众号列表接口对 `total` 的计算存在偏差，原本会无条件额外加 1，导致部分场景下分页总数不准确。

  ## 修改
  - 前端在切换公众号启用/停用成功后，改为重新请求当前分页的公众号列表。
  - 后端修正公众号列表 `total` 计算逻辑，仅在“全部 + 无搜索 + 首页”且实际插入“精选文章”项时才额外计数。

  ## 结果
  - 切换公众号启用/停用后，当前页列表会按最新结果自动补齐。
  - 分页数量和总数展示恢复正确，不再出现 10 条变 9 条、8 条的问题。