### PR TITLE
[codex] fix token expiry status

### DIFF
--- a/driver/success.py
+++ b/driver/success.py
@@ -4,6 +4,7 @@ from .token import set_token
 from core.print import print_warning,print_success
 from core.redis_client import redis_client
 import json
+import time
 #判断是否是有效登录 
 
 # 初始化全局变量（作为Redis不可用时的回退）
@@ -17,6 +18,30 @@ login_lock = threading.Lock()
 
 # Redis key 常量
 REDIS_KEY_STATUS = "werss:login:status"
+
+def _is_token_data_valid(token_data: dict | None) -> bool:
+    if not token_data or not token_data.get("token"):
+        return False
+
+    expiry = token_data.get("expiry")
+    if not expiry:
+        return True
+
+    expiry_timestamp = expiry.get("expiry_timestamp")
+    if expiry_timestamp is not None:
+        try:
+            return float(expiry_timestamp) > time.time()
+        except (TypeError, ValueError):
+            pass
+
+    remaining = expiry.get("remaining_seconds")
+    if remaining is not None:
+        try:
+            return float(remaining) > 0
+        except (TypeError, ValueError):
+            pass
+
+    return True
 
 def setStatus(status:bool):
     """设置登录状态，优先存储到Redis，失败则使用全局变量"""
@@ -34,46 +59,30 @@ def setStatus(status:bool):
 def getStatus():
     """获取登录状态，优先从Redis读取，失败则使用全局变量，并检查token是否过期"""
     global WX_LOGIN_ED
-    import time
 
     # 尝试从Redis读取
     if redis_client.is_connected:
         try:
             val = redis_client._client.get(REDIS_KEY_STATUS)
             if val is not None and val == "1":
-                # 检查token是否过期
-                token_data = getLoginInfo()
-                if token_data and 'expiry' in token_data and token_data['expiry']:
-                    expiry = token_data['expiry']
-                    # 检查剩余秒数
-                    if 'remaining_seconds' in expiry:
-                        remaining = expiry['remaining_seconds']
-                        if remaining is not None and remaining > 0:
-                            return True
-                        else:
-                            # token已过期，更新状态
-                            print_warning("Token已过期，需要重新登录")
-                            setStatus(False)
-                            return False
-                    # 检查过期时间戳
-                    elif 'expiry_timestamp' in expiry:
-                        expiry_timestamp = expiry['expiry_timestamp']
-                        # 过期时间戳 >= 当前时间，说明还没过期
-                        if expiry_timestamp and expiry_timestamp >= time.time():
-                            return True
-                        else:
-                            # token已过期，更新状态
-                            print_warning("Token已过期，需要重新登录")
-                            setStatus(False)
-                            return False
-                # 没有过期信息，但状态为True，暂时返回True
-                return True
+                if _is_token_data_valid(getLoginInfo()):
+                    return True
+                print_warning("Token已过期或不存在，需要重新登录")
+                setStatus(False)
+                return False
         except Exception as e:
             print_warning(f"检查登录状态失败: {e}")
             pass
     # 回退到全局变量
     with login_lock:
-        return WX_LOGIN_ED
+        status = WX_LOGIN_ED
+    if not status:
+        return False
+    if _is_token_data_valid(getLoginInfo()):
+        return True
+    print_warning("Token已过期或不存在，需要重新登录")
+    setStatus(False)
+    return False
 def getLoginInfo():
     from driver.token import _get_token_data
     return _get_token_data()
@@ -108,7 +117,6 @@ def Success(data:dict,ext_data:dict={}):
 
 def CanGetToken():
     """检查是否可以获取Token，包括检查登录状态和token过期时间"""
-    import time
 
     # 检查登录状态
     if not getStatus():
@@ -122,22 +130,9 @@ def CanGetToken():
         setStatus(False)
         return False
 
-    # 检查过期信息
-    expiry = token_data.get('expiry')
-    if expiry:
-        # 检查剩余秒数
-        if 'remaining_seconds' in expiry:
-            remaining = expiry['remaining_seconds']
-            if remaining is not None and remaining <= 0:
-                print_warning("Token已过期，请重新扫码登录")
-                setStatus(False)
-                return False
-        # 检查过期时间戳
-        elif 'expiry_timestamp' in expiry:
-            expiry_timestamp = expiry['expiry_timestamp']
-            if expiry_timestamp and expiry_timestamp <= time.time():
-                print_warning("Token已过期，请重新扫码登录")
-                setStatus(False)
-                return False
+    if not _is_token_data_valid(token_data):
+        print_warning("Token已过期，请重新扫码登录")
+        setStatus(False)
+        return False
 
     return True


### PR DESCRIPTION
## Summary
- Treat stored token data as unauthenticated when `expiry_timestamp` is already in the past
- Prefer `expiry_timestamp` over stored `remaining_seconds`, because `remaining_seconds` can become stale after the token is saved
- Clear login status when the stored token is expired or missing

## Validation
- `PYTHONDONTWRITEBYTECODE=1 uv run python -m py_compile driver/success.py`
- Deployed the same fix to a Docker service and verified an expired runtime token now reports `getStatus=False` and `CanGetToken=False`
