### PR TITLE
fix: FETCHING lock not released after successful content sync

### DIFF
--- a/jobs/fetch_no_article.py
+++ b/jobs/fetch_no_article.py
@@ -53,6 +53,9 @@ def fetch_articles_without_content():
                         print_error(f"获取文章 {article.title} 内容已被发布者删除")
                     else:
                         print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:8001/views/article/{article.id}")
+                        # 成功获取内容后，恢复原始状态（通常为 ACTIVE），释放 FETCHING 锁
+                        article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
+                        session.commit()
                 else:
                     # 获取失败，恢复状态以便后续重试
                     article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)


### PR DESCRIPTION
## Bug Description

In `jobs/fetch_no_article.py`, the `fetch_articles_without_content()` function has a locking mechanism using `DATA_STATUS.FETCHING` (status=6) to prevent duplicate content fetching across multiple nodes. However, when the content fetch **succeeds**, the status is never reset back to `ACTIVE` (status=1), causing articles to be permanently stuck in FETCHING state and invisible on the website.

## Root Cause

The success branch (line 55-56) only prints a log message but **does not restore the article status**:

```python
if updated:
    if article.status == DATA_STATUS.DELETED:
        print_error(...)
    else:
        print_success(...)   # ← Status NOT reset to ACTIVE
else:
    # Failure path correctly restores status:
    article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
    session.commit()
```

## Impact

On a deployed instance with ~30K articles, **88 articles** were found stuck at status=6. Of these, **79 had fully fetched content** but were invisible to users (404 on article detail page). The remaining 9 had no content and were blocked from retry.

## Fix

Add status restoration in the success branch, identical to the existing failure path:

```python
if updated:
    if article.status == DATA_STATUS.DELETED:
        print_error(...)
    else:
        print_success(...)
        # Restore original status, release FETCHING lock
        article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
        session.commit()
```

## Verification

- Applied the fix and verified all 88 stuck articles became visible
- No side effects — the status restoration is the same logic used in the failure and exception paths