### PR TITLE
fix: ensure expired notification is always sent regardless of send_code config

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -170,7 +170,7 @@ http://localhost:3000
 | `WEB_NAME` | `WeRSS微信公众号订阅助手` | 前端显示名称 |
 | `WERSS_AUTH_WEB` | `False` | 通过web方式授权 |
 | `BROWSER_TYPE` | `firefox` | 浏览器类型默认firefox |
-| `SEND_CODE` | `True` | 是否发送授权二维码通知 |
+| `SEND_CODE` | `False` | 过期通知中是否附带授权二维码（默认仅发送文字通知） |
 | `CODE_TITLE` | `WeRSS授权二维码` | 二维码通知标题 |
 | `ENABLE_JOB` | `True` | 是否启用定时任务 |
 | `AUTO_RELOAD` | `False` | 代码修改自动重启服务 |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -220,7 +220,7 @@ The following are the environment variable configurations supported in `config.y
 | `APP_NAME` | `we-mp-rss` | Application name |
 | `SERVER_NAME` | `we-mp-rss` | Server name |
 | `WEB_NAME` | `WeRSS微信公众号订阅助手` | Frontend display name |
-| `SEND_CODE` | `True` | Whether to send authorization QR code notifications |
+| `SEND_CODE` | `False` | Whether to send authorization QR code in expired notification (text-only notification by default) |
 | `CODE_TITLE` | `WeRSS授权二维码` | QR code notification title |
 | `ENABLE_JOB` | `True` | Whether to enable scheduled tasks |
 | `AUTO_RELOAD` | `False` | Auto-restart service on code changes |

--- a/config-node.yaml
+++ b/config-node.yaml
@@ -4,8 +4,8 @@ server:
    name: ${SERVER_NAME:-we-mp-rss}
    #前端显示名称
    web_name: ${WEB_NAME:-WeRSS微信公众号订阅助手}
-   #过期是否发送授权二维通知 默认True
-   send_code: ${SEND_CODE:-True}
+   #过期是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${SEND_CODE:-False}
    #二维通知标题
    code_title: ${CODE_TITLE:-WeRSS}
    #启动JOB定时任务，默认为True
@@ -16,8 +16,8 @@ server:
    threads: ${THREADS:-1}
    #通过web方式授权二维码 默认False 
    auth_web: ${WERSS_AUTH_WEB:-False}
-   #是否发送授权二维通知 默认True
-   send_code: ${WERSS_SEND_CODE:-True}
+   #是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${WERSS_SEND_CODE:-False}
 
 
 #数据库连接 例如db:  mysql+pymysql://<username>:<password>@<host>/we-rss?charset=utf8mb4

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,8 +4,8 @@ server:
    name: ${SERVER_NAME:-we-mp-rss}
    #前端显示名称
    web_name: ${WEB_NAME:-WeRSS微信公众号订阅助手}
-   #过期是否发送授权二维通知 默认True
-   send_code: ${SEND_CODE:-True}
+   #过期是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${SEND_CODE:-False}
    #二维通知标题
    code_title: ${CODE_TITLE:-WeRSS}
    #启动JOB定时任务，默认为True
@@ -16,8 +16,8 @@ server:
    threads: ${THREADS:-1}
    #通过web方式授权二维码 默认False 
    auth_web: ${WERSS_AUTH_WEB:-False}
-   #是否发送授权二维通知 默认True
-   send_code: ${WERSS_SEND_CODE:-True}
+   #是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${WERSS_SEND_CODE:-False}
    #是否启用自动刷新文章统计 默认False
    article_stats_refresh_enabled: ${ARTICLE_STATS_REFRESH_ENABLED:-False}
    # 文章统计刷新间隔 默认300秒

--- a/core/wx/base.py
+++ b/core/wx/base.py
@@ -320,11 +320,10 @@ class WxGather:
         if code=="Invalid Session":
             # from core.queue import TaskQueue
             # TaskQueue.clear_queue()  # 已注释：避免微信认证失效时清空队列
-            if cfg.get("server.send_code")=="True":
-                from jobs.failauth import send_wx_code
-                import threading
-                setStatus(False)
-                threading.Thread(target=send_wx_code,args=(f"公众号平台登录失效,请重新登录",)).start()
+            from jobs.failauth import send_wx_code
+            import threading
+            setStatus(False)
+            threading.Thread(target=send_wx_code,args=(f"公众号平台登录失效,请重新登录",)).start()
             # send_wx_code(f"公众号平台登录失效,请重新登录")
             raise Exception(error)
         # raise Exception(error)

--- a/jobs/failauth.py
+++ b/jobs/failauth.py
@@ -1,4 +1,4 @@
-from core.print import print_warning
+from core.print import print_warning, print_info
 from driver.base import WX_API
 from core.config import cfg
 from jobs.notice import sys_notice
@@ -6,22 +6,59 @@ from driver.success import Success
 from tools.base64_tools import image_to_base64
 import time
 
-def send_wx_code(title:str="",url:str=""):
-    if cfg.get("server.send_code",False):
-        WX_API.GetCode(Notice=CallBackNotice,CallBack=Success)
-    pass
-def CallBackNotice(data=None,ext_data=None):
-        if data is not None:
-            print_warning(data)
-            return 
-        img_path=WX_API.QRcode()['code']
-        rss_domain=str(cfg.get("rss.base_url",""))
-        url=rss_domain+str(img_path)
-        url=image_to_base64("./static/wx_qrcode.png")
-        text=f"- 服务名：{cfg.get('server.name','')}\n"
-        text+=f"- 发送时间： {time.strftime('%Y-%m-%d %H:%M:%S',time.localtime(time.time()))}"
-        if WX_API.GetHasCode():
-            text+=f"![描述]({url})"
-            # text+=f"<img src='{url}' width='100' height='100'/>"
-            text+=f"\n- 请使用微信扫描二维码进行授权"
-        sys_notice(text, str(cfg.get("server.code_title","WeRss授权过期,扫码授权")))
+
+def send_wx_code(title: str = "", url: str = ""):
+    """发送微信授权过期通知
+
+    始终发送过期通知。当 send_code=True 时，尝试获取二维码并附带在通知中；
+    当 send_code=False 时，只发送文字通知（不含二维码）。
+    """
+    # 始终发送过期通知（不依赖 send_code 配置）
+    text = f"- 服务名：{cfg.get('server.name', '')}\n"
+    text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}\n"
+    if title:
+        text += f"- 原因：{title}\n"
+
+    notice_title = str(cfg.get("server.code_title", "WeRss授权过期,扫码授权"))
+
+    if cfg.get("server.send_code", False):
+        # send_code=True: 尝试获取二维码，通过回调发送含二维码的通知
+        WX_API.GetCode(Notice=CallBackNotice, CallBack=Success)
+    else:
+        # send_code=False: 直接发送不含二维码的文字通知
+        text += "- 请手动访问系统进行扫码登录"
+        try:
+            sys_notice(text=text, title=notice_title)
+            print_info(f"已发送授权过期通知(无二维码): {notice_title}")
+        except Exception as e:
+            print_warning(f"发送授权过期通知失败: {e}")
+
+
+def CallBackNotice(data=None, ext_data=None):
+    """获取二维码过程中的回调通知"""
+    if data is not None:
+        print_warning(data)
+        # 获取二维码出错时，发送不含二维码的通知提醒用户手动登录
+        text = f"- 服务名：{cfg.get('server.name', '')}\n"
+        text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}\n"
+        text += f"- 获取二维码失败：{data}\n"
+        text += "- 请手动访问系统进行扫码登录"
+        try:
+            sys_notice(
+                text=text,
+                title=str(cfg.get("server.code_title", "WeRss授权过期"))
+            )
+        except Exception as e:
+            print_warning(f"发送二维码获取失败通知失败: {e}")
+        return
+
+    img_path = WX_API.QRcode()['code']
+    rss_domain = str(cfg.get("rss.base_url", ""))
+    url = rss_domain + str(img_path)
+    url = image_to_base64("./static/wx_qrcode.png")
+    text = f"- 服务名：{cfg.get('server.name', '')}\n"
+    text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}"
+    if WX_API.GetHasCode():
+        text += f"![描述]({url})"
+        text += f"\n- 请使用微信扫描二维码进行授权"
+    sys_notice(text, str(cfg.get("server.code_title", "WeRss授权过期,扫码授权")))


### PR DESCRIPTION
## 问题描述

微信授权过期后，系统不发送任何通知。原 `send_wx_code()` 函数只在 `send_code=True` 时才执行 `WX_API.GetCode()`，且 `title` 参数（过期原因）完全被忽略。当 `send_code=False` 或获取二维码失败时，过期后完全没有通知。

## 修改内容

- **jobs/failauth.py**: `send_wx_code()` 始终调用 `sys_notice()` 发送过期通知
  - `send_code=False`（默认）: 发送不含二维码的文字通知，提示手动登录
  - `send_code=True`: 保持原流程，通过回调发送含二维码的通知
  - `CallBackNotice` 获取二维码失败时也发送通知提醒手动登录
  - `title` 参数现在会显示在通知的原因字段
- **core/wx/base.py**: 移除 `Error()` 方法中的 `send_code` 条件判断，始终调用 `send_wx_code`
- **config.example.yaml / config-node.yaml**: `SEND_CODE` 默认值从 `True` 改为 `False`
- **ReadMe.md / README.zh-CN.md**: 更新 `SEND_CODE` 环境变量说明

## 配置迁移说明

- `SEND_CODE` 默认值从 `True` 变为 `False`，过期通知默认只发送文字（不含二维码）
- 如需在过期通知中附带二维码，需显式设置 `SEND_CODE=True`