### PR TITLE
fix: add timeout to all HTTP requests to prevent indefinite hangs

### DIFF
--- a/core/notice/custom.py
+++ b/core/notice/custom.py
@@ -20,7 +20,8 @@ def send_custom_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/dingtalk.py
+++ b/core/notice/dingtalk.py
@@ -27,7 +27,8 @@ def send_dingtalk_message(webhook_url, title, text, is_at_all=False, at_mobiles=
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/feishu.py
+++ b/core/notice/feishu.py
@@ -40,7 +40,8 @@ def send_feishu_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/wechat.py
+++ b/core/notice/wechat.py
@@ -24,7 +24,8 @@ def send_wechat_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -57,7 +57,7 @@ class MpsWeb(WxGather):
             time.sleep(random.randint(0,interval))
             try:
                 headers = self.fix_header(url)
-                resp = session.get(url, headers=headers, params = params, verify=False)
+                resp = session.get(url, headers=headers, params = params, verify=False, timeout=(10, 30))
                 
                 msg = resp.json()
                 self._cookies =resp.cookies

--- a/jobs/webhook.py
+++ b/jobs/webhook.py
@@ -196,7 +196,8 @@ def call_webhook(hook: MessageWebHook, is_test: bool = False) -> str:
             hook.task.web_hook_url,
             data=payload,
             headers=headers,
-            cookies=cookies
+            cookies=cookies,
+            timeout=30
         )
         response.raise_for_status()
         return "Webhook调用成功"


### PR DESCRIPTION
## Summary

The Python `requests` library defaults to `timeout=None` (infinite wait). When a remote server becomes unresponsive, the calling thread blocks permanently. This PR adds explicit timeouts to all HTTP requests that were missing them.

## Changes

| File | Change |
|------|--------|
| `core/wx/model/web.py` | `session.get()` add `timeout=(10, 30)` |
| `core/notice/custom.py` | `requests.post()` add `timeout=30` |
| `core/notice/wechat.py` | `requests.post()` add `timeout=30` |
| `core/notice/dingtalk.py` | `requests.post()` add `timeout=30` |
| `core/notice/feishu.py` | `requests.post()` add `timeout=30` |
| `jobs/webhook.py` | `requests.post()` add `timeout=30` |

Note: `core/notice/bark.py` already had `timeout=10` and was not changed.

## Motivation

Without these timeouts, any network hiccup or unresponsive webhook URL hangs a thread indefinitely. A single hung thread blocks the queue worker permanently, stopping all subsequent task processing.