### PR TITLE
fix: prevent event loop blocking and add queue task timeout

### DIFF
--- a/apis/message_task.py
+++ b/apis/message_task.py
@@ -1,3 +1,4 @@
+import asyncio
 from pydantic import BaseModel
 
 # 标准导入分组和顺序
@@ -148,7 +149,7 @@ async def test_message_task(
             articles=mock_articles  # type: ignore
         )
         
-        result = web_hook(test_hook, is_test=True)
+        result = await asyncio.to_thread(web_hook, test_hook, is_test=True)
         
         return success_response(
             data={

--- a/core/queue/queue.py
+++ b/core/queue/queue.py
@@ -6,6 +6,7 @@ import json
 from typing import Callable, Any, Optional
 from datetime import datetime
 from dataclasses import dataclass, field, asdict
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from core.print import print_error, print_info, print_warning, print_success
 
 # Redis 键前缀 - 主队列（文章列表采集）
@@ -457,7 +458,15 @@ class TaskQueueManager:
                         try:
                             # 记录任务开始时间
                             start_time = time.time()
-                            task(*args, **kwargs)
+                            task_executor = ThreadPoolExecutor(max_workers=1)
+                            try:
+                                future = task_executor.submit(task, *args, **kwargs)
+                                future.result(timeout=600)
+                            except FutureTimeoutError:
+                                print_error("Task [{}] execution timeout (10 min)".format(task_name))
+                                raise Exception("Task timed out after 600s")
+                            finally:
+                                task_executor.shutdown(wait=False)
                             # 记录任务执行时间
                             duration = time.time() - start_time
                             


### PR DESCRIPTION
## Summary

Two related fixes for server unresponsiveness when tasks hang.

## Changes

### 1. `apis/message_task.py` — Prevent event loop blocking

`test_message_task` is an `async def` endpoint that called `web_hook()` synchronously. If the webhook request hangs (e.g. unresponsive webhook URL with no timeout), this blocks the entire uvicorn event loop, causing the server to stop responding to ALL HTTP requests.

Changed to `await asyncio.to_thread(web_hook, ...)` so the blocking call runs in a thread pool without stalling the event loop.

### 2. `core/queue/queue.py` — Queue task timeout

The queue worker thread executes tasks with no timeout. A single hung task blocks all subsequent tasks permanently. Wrapped the `task(*args, **kwargs)` execution in a `ThreadPoolExecutor` with `future.result(timeout=600)` so the worker can recover and continue processing remaining tasks after a 10-minute timeout.

## Motivation

When a task hangs (e.g. webhook timeout, WeChat API unresponsive), the consequences cascade:
1. Queue worker thread is blocked permanently
2. If called from the async endpoint, the event loop is blocked
3. Scheduled cron jobs can't execute
4. The only recovery is a container restart

With these fixes, the server gracefully recovers from hung tasks.