### PR TITLE
fix: enable SQLite WAL mode and filter invalid faker_id

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -69,6 +69,9 @@ class Db:
                 @event.listens_for(self.engine, "connect")
                 def set_sqlite_text_factory(dbapi_conn, connection_record):
                     # 将无效 UTF-8 字符替换为 �
+                    dbapi_conn.execute("PRAGMA journal_mode=WAL")
+                    dbapi_conn.execute("PRAGMA busy_timeout=10000")
+                    dbapi_conn.execute("PRAGMA synchronous=NORMAL")
                     dbapi_conn.text_factory = lambda x: x.decode('utf-8', errors='replace')
             
             self.session_factory=self.get_session_factory()
@@ -229,7 +232,7 @@ class Db:
         session = None
         try:
             session = self.get_session()
-            return session.query(Feed).filter(Feed.status == 1).all()
+            return session.query(Feed).filter(Feed.status == 1, Feed.faker_id != "MP_WXS_FEATURED_ARTICLES").all()
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore


### PR DESCRIPTION
## Summary

Two database-level fixes.

## Changes

### 1. Enable SQLite WAL mode

Adds the following PRAGMAs on each new database connection in the `connect` event listener:

- `journal_mode=WAL` — Write-Ahead Logging allows concurrent readers and writers. The default `delete` mode serializes all access, causing readers to block writers and vice versa.
- `busy_timeout=10000` — Wait 10 seconds before failing on lock contention, instead of immediate failure.
- `synchronous=NORMAL` — Balances crash safety with write performance.

This is important because the app has multiple threads accessing SQLite concurrently: two queue worker threads, uvicorn request handlers, APScheduler cron jobs, and content extraction workers.

### 2. Filter invalid faker_id

The `get_all_mps()` method now filters out feeds where `faker_id = "MP_WXS_FEATURED_ARTICLES"`. This is a special placeholder feed whose faker_id is literally the string `"MP_WXS_FEATURED_ARTICLES"` — not a valid WeChat base64 account identifier.

When this feed is queued as the first task, the WeChat API call fails or hangs because the ID is invalid, blocking the entire queue.

## Note

WAL mode is sticky — once set on a database file, it persists across all connections. However, setting it in the connect event ensures it's applied when the database file is first created.