### PR TITLE
fix: remove duplicate send_code config entry

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,8 +16,6 @@ server:
    threads: ${THREADS:-1}
    #通过web方式授权二维码 默认False 
    auth_web: ${WERSS_AUTH_WEB:-False}
-   #是否发送授权二维码通知 默认False，设为True时通知中附带二维码
-   send_code: ${WERSS_SEND_CODE:-False}
    #是否启用自动刷新文章统计 默认False
    article_stats_refresh_enabled: ${ARTICLE_STATS_REFRESH_ENABLED:-False}
    # 文章统计刷新间隔 默认300秒


### PR DESCRIPTION
## Summary

删除 `config.example.yaml` 中第 19-20 行重复的 `send_code` 配置项。

该配置项与第 7-8 行（server.send_code）完全重复，会导致配置歧义。

### Changes
- 删除 `config.example.yaml` 中重复的 `send_code` 注释和配置行（原第 19-20 行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)