### PR TITLE
fix: 修正日志中端口硬编码问题

### DIFF
--- a/jobs/fetch_no_article.py
+++ b/jobs/fetch_no_article.py
@@ -52,7 +52,7 @@ def fetch_articles_without_content():
                     if article.status == DATA_STATUS.DELETED:
                         print_error(f"获取文章 {article.title} 内容已被发布者删除")
                     else:
-                        print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:8001/views/article/{article.id}")
+                        print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:{cfg.get('port', 8001)}/views/article/{article.id}")
                         # 成功获取内容后，恢复原始状态（通常为 ACTIVE），释放 FETCHING 锁
                         article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
                         session.commit()


### PR DESCRIPTION
## 问题

 第 55 行将端口  硬编码在日志 URL 中，导致通过环境变量或 .env 修改端口后，日志输出的 URL 仍然显示旧端口。

## 改动

| 文件 | 变更 |
|------|------|
|  | 将硬编码的  替换为 ，从配置动态读取端口 |

## 验证

修改  环境变量后，日志输出的 URL 应与实际服务端口一致。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)