### PR TITLE
fix: 修正 gather.content 配置关闭后仍抓取全文的问题

### DIFF
--- a/core/wx/model/api.py
+++ b/core/wx/model/api.py
@@ -21,8 +21,7 @@ class MpsApi(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page=0,MaxPage:int=1,interval=10,Gather_Content=True,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-             Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"API获取模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsg"

--- a/core/wx/model/app.py
+++ b/core/wx/model/app.py
@@ -26,8 +26,7 @@ class MpsAppMsg(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-            Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"APP浏览器模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsgpublish"

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -26,8 +26,7 @@ class MpsWeb(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str='',Mps_id:str='',Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-            Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"Web浏览器模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsgpublish"


### PR DESCRIPTION
## 问题描述

当 `gather.content` 设为 `False` 时，API 模式下服务仍然会抓取文章的 `content_html` 全文内容。

## 根因分析

在三个模型（api / web / app）的 `get_Articles` 方法中，配置读取逻辑有缺陷：

```python
# 修复前
if self.Gather_Content:      # config 中 gather.content=False 时，跳过
    Gather_Content = True    # 不会执行
# → Gather_Content 保留函数参数默认值（API 模型默认为 True）
```

- API 模型的 `Gather_Content` 参数默认值是 `True`
- `self.Gather_Content`（来自配置 `gather.content`）为 `False` 时，条件不成立
- 局部变量 `Gather_Content` 永远不会被设为 `False`，始终为默认的 `True`

## 修复方式

将条件覆盖改为直接赋值，确保配置值始终生效：

```python
# 修复后
Gather_Content = self.Gather_Content
```

## 影响范围

| 模型 | 修复前（未配置时） | 修复后（未配置时） | 说明 |
|------|-------------------|-------------------|------|
| api  | 始终抓取内容 ✅ | 不抓取内容 | 之前配置不生效，现在正确 |
| web  | 不抓取内容 | 不抓取内容 | 行为不变 |
| app  | 不抓取内容 | 不抓取内容 | 行为不变 |

## 修改文件

- `core/wx/model/api.py` — 主要问题所在
- `core/wx/model/web.py` — 统一逻辑
- `core/wx/model/app.py` — 统一逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)