### PR TITLE
feat: 支持通过环境变量使用本地 Chrome，并新增反爬注入开关

### DIFF
--- a/driver/chrome_path.py
+++ b/driver/chrome_path.py
@@ -1,0 +1,52 @@
+"""
+跨平台解析本地 Chromium 内核浏览器（Chrome / Edge / Chromium）可执行文件路径。
+
+设计目标：
+- 不写死任何机器专属绝对路径（如某台 Windows 的 D:\\Tools\\...）。
+- 跨平台：Win11 / Docker-Linux / macOS 均可用。
+- 默认“不启用”：解析不到时返回 None，由调用方回退到 Playwright 自带浏览器，
+  从而保持上游默认行为（默认 webkit）完全不变，Docker/Linux 零回归。
+
+解析优先级：
+  1. 环境变量 CHROME_EXECUTABLE_PATH（跨平台、最高优先级，用户显式指定）
+  2. 当前操作系统的“标准安装位置”自动发现（仅当文件确实存在时才采用）
+  3. 都没有 -> 返回 None
+"""
+import os
+import sys
+
+# 仅收录各平台“标准”安装位置；不含任何机器专属路径。
+# 找不到时列表自然跳过，返回 None（调用方回退自带浏览器）。
+_CANDIDATES = {
+    "win32": [
+        os.path.expandvars(r"%ProgramFiles%\Google\Chrome\Application\chrome.exe"),
+        os.path.expandvars(r"%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe"),
+        os.path.expandvars(r"%ProgramFiles%\Microsoft\Edge\Application\msedge.exe"),
+        os.path.expandvars(r"%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe"),
+    ],
+    "linux": [
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser",
+    ],
+    "darwin": [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    ],
+}
+
+
+def get_chrome_executable_path() -> "str | None":
+    """返回可用的 Chromium 内核浏览器可执行文件路径；无则返回 None。
+
+    返回 None 时，调用方应保持原有浏览器类型（如上游默认的 webkit），
+    由 Playwright 启动其自带浏览器，确保 Docker/Linux 默认行为不变。
+    """
+    env = os.environ.get("CHROME_EXECUTABLE_PATH")
+    if env and os.path.exists(env):
+        return env
+    for cand in _CANDIDATES.get(sys.platform, []):
+        if cand and os.path.exists(cand):
+            return cand
+    return None

--- a/driver/playwright_driver.py
+++ b/driver/playwright_driver.py
@@ -18,6 +18,7 @@ if sys.platform == 'win32':
 
 from core.print import print_error, print_info, print_warning
 from driver.anti_crawler_config import AntiCrawlerConfig
+from driver.chrome_path import get_chrome_executable_path
 
 @dataclass
 class Metrics:
@@ -54,7 +55,8 @@ class PlaywrightController:
                  proxy_url: Optional[str] = "",
                  user_agent: Optional[str] = None,
                  debug: bool = False,
-                 mobile_mode: bool = False):
+                 mobile_mode: bool = False,
+                 apply_anti_crawler: bool = True):
         """
         初始化异步控制器
 
@@ -72,6 +74,11 @@ class PlaywrightController:
         self.proxy_url = proxy_url
         self.debug = debug
         self.mobile_mode = mobile_mode
+        # 是否应用反爬虫注入（extra_http_headers + 反检测脚本）。
+        # 反爬头含 Cache-Control / Sec-Fetch-* 等非 CORS 安全头，会触发跨域预检，
+        # 导致部分站点（如微信公众平台登录页）自身 JS 资源加载失败、二维码无法渲染。
+        # 微信登录等场景需退化为普通浏览器，故提供关闭开关。
+        self.apply_anti_crawler = apply_anti_crawler
 
         # 反爬虫配置实例
         self.anti_crawler_config = AntiCrawlerConfig()
@@ -119,6 +126,15 @@ class PlaywrightController:
             # 启动 Playwright
             self._playwright = await async_playwright().start()
 
+            # ===== 本地 Chrome 支持（可选，避免强制 playwright install 下载浏览器）=====
+            # 仅当通过环境变量 CHROME_EXECUTABLE_PATH 显式指定（或自动发现到本机标准安装的
+            # Chromium 内核浏览器）时才启用；否则保持上游默认浏览器（默认 webkit，由 Playwright 自带），
+            # 跨平台可移植，Docker/Linux 默认行为不受影响。
+            CHROME_PATH = get_chrome_executable_path()
+            if CHROME_PATH:
+                self.browser_type = "chromium"
+                print_info(f"使用本地 Chrome: {CHROME_PATH}（跳过 Playwright 浏览器下载）")
+
             # 选择浏览器类型
             browser_launcher = getattr(self._playwright, self.browser_type)
 
@@ -138,6 +154,9 @@ class PlaywrightController:
                     "--disable-dev-shm-usage",
                     "--no-sandbox",
                 ]
+                # 使用本地 Chrome 可执行文件，避免下载 Playwright 浏览器
+                if CHROME_PATH:
+                    launch_options["executable_path"] = CHROME_PATH
 
             # 添加代理
             if self.proxy_url:
@@ -157,8 +176,8 @@ class PlaywrightController:
                 "timezone_id": "Asia/Shanghai",
             }
 
-            # 应用额外的HTTP头
-            if "extra_http_headers" in anti_config:
+            # 应用额外的HTTP头（反爬注入可能破坏跨域资源加载，关闭时跳过）
+            if self.apply_anti_crawler and "extra_http_headers" in anti_config:
                 context_options["extra_http_headers"] = anti_config["extra_http_headers"]
 
             # 应用其他可选配置
@@ -171,8 +190,9 @@ class PlaywrightController:
             # 创建页面
             self._page = await self._context.new_page()
 
-            # ========== 核心改造：注入反检测脚本 ==========
-            await self._apply_anti_crawler_scripts(self._page)
+            # ========== 核心改造：注入反检测脚本（关闭反爬时跳过）==========
+            if self.apply_anti_crawler:
+                await self._apply_anti_crawler_scripts(self._page)
 
             # 记录启动时间
             self.metrics.browser_startup_time = time.time() - start_time

--- a/tools/mdtools/pdf.py
+++ b/tools/mdtools/pdf.py
@@ -44,11 +44,13 @@
 """
 import asyncio
 import sys
+import os
 import atexit
 from typing import Optional, Dict, Any
 from pathlib import Path
 from playwright.async_api import async_playwright, Browser, Page, BrowserContext
 import logging
+from driver.chrome_path import get_chrome_executable_path
 
 # Windows 平台需要使用 ProactorEventLoop 以支持子进程
 # Playwright 需要启动浏览器子进程，必须使用 ProactorEventLoop
@@ -96,9 +98,17 @@ class WebToPDFConverter:
     async def _ensure_browser(self) -> Browser:
         """确保浏览器已启动"""
         if self._browser is None:
+            # ===== 本地 Chrome 支持（可选，避免强制 playwright install 下载浏览器）=====
+            # 仅当通过环境变量 CHROME_EXECUTABLE_PATH 指定（或自动发现到本机标准 Chromium 浏览器）时启用。
+            CHROME_PATH = get_chrome_executable_path()
+            if CHROME_PATH:
+                self.browser_type = "chromium"
             self._playwright = await async_playwright().start()
+            launch_kwargs = {"headless": self.headless}
+            if self.browser_type == "chromium" and CHROME_PATH:
+                launch_kwargs["executable_path"] = CHROME_PATH
             if self.browser_type == "chromium":
-                self._browser = await self._playwright.chromium.launch(headless=self.headless)
+                self._browser = await self._playwright.chromium.launch(**launch_kwargs)
             elif self.browser_type == "firefox":
                 self._browser = await self._playwright.firefox.launch(headless=self.headless)
             elif self.browser_type == "webkit":


### PR DESCRIPTION
## 背景
当前 `PlaywrightController` 在离线 / 受限网络或数据中心 IP 被封环境下，会强制触发 `playwright install` 下载浏览器，导致启动失败；同时反爬注入含非 CORS 安全头，会让微信公众平台登录页自身的 JS 资源因跨域预检失败而无法加载。

## 改动
- 新增 `driver/chrome_path.py`：按「环境变量 `CHROME_EXECUTABLE_PATH` > 系统标准安装位置 > None」解析本地 Chromium，**不写死任何机器专属绝对路径**。为 `None` 时回退到 Playwright 自带浏览器，Docker / Linux 默认行为完全不变。
- `driver/playwright_driver.py` / `tools/mdtools/pdf.py` 改用该 helper，避免强制下载浏览器。
- 新增 `apply_anti_crawler` 开关（**默认 `True`，向后兼容**）：关闭后跳过反爬注入，解决部分站点（如微信登录页）JS 资源被 CORS 预检拦截的问题。

## 兼容性
- Win11：设 `CHROME_EXECUTABLE_PATH` 即用本地 Chrome 并跳过下载；不设则自动发现 Chrome / Edge。
- Docker / Linux（默认不设）：回退 Playwright 自带浏览器，与上游现有行为零回归。
- Docker / Linux（已装 chromium）：设 `CHROME_EXECUTABLE_PATH=/usr/bin/chromium` 即可离线运行。

## 测试
本地 Win11 + 本地 Chrome 场景启动正常；`py_compile` 通过。