### PR TITLE
fix: 修复扫码授权二维码无法显示的问题

### DIFF
--- a/driver/anti_crawler_config.py
+++ b/driver/anti_crawler_config.py
@@ -30,8 +30,7 @@ class AntiCrawlerConfig:
             "zh-CN,zh;q=0.9,en;q=0.8",
             "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2",
             "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7"
-        ],
-        'cache_control': ["no-cache", "max-age=0", "no-store"]
+        ]
     }
     
     # 时区配置
@@ -94,8 +93,11 @@ class AntiCrawlerConfig:
             "Accept": random.choice(self.HEADERS['accept']),
             "Accept-Language": random.choice(self.HEADERS['accept_language']),
             "Accept-Encoding": "gzip, deflate, br",
-            "Cache-Control": random.choice(self.HEADERS['cache_control']),
-            "Upgrade-Insecure-Requests": "1",
+            # 注意：不能设置 Cache-Control 和 Upgrade-Insecure-Requests。
+            # extra_http_headers 会作用于页面发出的所有请求（包括XHR），
+            # 而真实浏览器只在页面导航请求上带这两个头；
+            # 带上后 mp.weixin.qq.com 登录页初始化失败，
+            # #app 一直保持 visibility:hidden，登录二维码无法加载
             "Sec-Fetch-Dest": "document",
             "Sec-Fetch-Mode": "navigate",
             "Sec-Fetch-Site": "none",

--- a/driver/wx.py
+++ b/driver/wx.py
@@ -436,6 +436,38 @@ class Wx:
                 except Exception as e:
                     print(f"二维码图片获取失败: {str(e)}")
         return self.isLock
+    async def _wait_qrcode_ready(self, page, qr_tag, timeout=30):
+        """等待登录二维码图片加载完成（异步）
+
+        新版登录页可能默认展示"微信快捷登录"（open.weixin.qq.com iframe），
+        此时经典二维码处于隐藏状态且src为空，直接截图会得到空白图片或超时。
+        检测到该情况时点击"扫码登录"链接切换回二维码登录，
+        再等待二维码图片可见且真正加载完成。
+        """
+        import asyncio
+
+        deadline = time.time() + timeout
+        switch_clicked = False
+        while time.time() < deadline:
+            ready = await page.evaluate(
+                """(sel) => {
+                    const img = document.querySelector(sel);
+                    if (!img) return false;
+                    const style = window.getComputedStyle(img);
+                    if (style.display === 'none' || style.visibility === 'hidden') return false;
+                    return !!img.src && img.complete && img.naturalWidth > 50;
+                }""", qr_tag)
+            if ready:
+                return True
+            if not switch_clicked:
+                switch_link = page.locator("a.login__type__container__link_text", has_text="扫码登录")
+                if await switch_link.count() > 0 and await switch_link.first.is_visible():
+                    print_info("检测到快捷登录页面，切换到扫码登录...")
+                    await switch_link.first.click()
+                    switch_clicked = True
+            await asyncio.sleep(0.5)
+        return False
+
     async def wxLogin(self, CallBack=None, NeedExit=True):
         """
         微信公众平台登录流程（异步）：
@@ -474,11 +506,20 @@ class Wx:
             page = driver.page
 
             # 等待页面完全加载
+            # 新版登录页存在持续的轮询请求，networkidle可能永远不触发，
+            # 超时不视为错误，由后续二维码加载检测兜底
             print_info("正在加载登录页面...")
-            await page.wait_for_load_state("networkidle")
+            try:
+                await page.wait_for_load_state("networkidle", timeout=10000)
+            except Exception:
+                pass
 
             # 定位二维码区域
             qr_tag = ".login__type__container__scan__qrcode"
+            # 新版登录页可能默认展示"微信快捷登录"，二维码被隐藏或src为空，
+            # 需要先切换回扫码登录并等待二维码图片真正加载完成
+            if not await self._wait_qrcode_ready(page, qr_tag):
+                raise Exception("二维码加载超时，请重试")
             # 获取二维码图片URL
             qrcode = await page.query_selector(qr_tag)
             code_src = await qrcode.get_attribute("src")
@@ -503,7 +544,10 @@ class Wx:
                 if self.WX_HOME in current_url:
                     print(f"登录成功，正在获取cookie和token...")
             page.on('framenavigated', handle_frame_navigated)
-            await page.wait_for_event("framenavigated", timeout=5*60 * 1000)
+            # 只等待主页面跳转到公众平台首页，
+            # 不能用 wait_for_event("framenavigated")：页面内的快捷登录iframe
+            # 加载时也会触发该事件，导致未扫码就误判为登录成功
+            await page.wait_for_url(lambda url: "cgi-bin/home" in url, timeout=5*60 * 1000)
 
             from .success import setStatus
             with self._login_lock:


### PR DESCRIPTION
Fixes #425

## 问题现象

点击"扫码授权"后二维码一直无法显示，后端日志表现为前端对 `/static/wx_qrcode.png` 的 HEAD 轮询持续 404（与 #425 中的日志一致）。

## 根因分析（三个问题叠加）

**1. 反爬请求头导致登录页初始化失败（主因，100% 复现）**

`anti_crawler_config.py` 通过 Playwright 的 `extra_http_headers` 注入 `Cache-Control` 和 `Upgrade-Insecure-Requests`。`extra_http_headers` 会作用于页面发出的**所有**请求（包括 XHR），而真实浏览器只在页面导航请求上发送这两个头。微信登录页检测到异常后中止初始化：`#app` 一直保持 `visibility:hidden`（整页空白），二维码 `src` 永远不会被请求，截图文件自然无法生成。

经逐个 header 二分测试确认：带上任一（`no-cache` / `max-age=0` / `no-store` 任意值的 `Cache-Control`，或 `Upgrade-Insecure-Requests: 1`）登录页 100% 白屏；移除后 100% 正常。

**2. `framenavigated` 事件导致登录成功误判**

新版登录页内嵌"微信快捷登录" iframe（`open.weixin.qq.com/cgi-bin/mpqrconnect`），其加载会触发 `framenavigated` 事件，导致 `wait_for_event("framenavigated")` 在未扫码时立即返回——日志中出现假的"登录成功！"和空 Token，随后 `finally` 中的 `Clean()` 把刚生成的二维码删掉，前端继续 404。改为 `wait_for_url` 等待主页面真正跳转到 `cgi-bin/home`。

**3. 页面加载与截图时序问题**

- 新版登录页存在持续轮询请求，`wxLogin` 中无超时保护的 `wait_for_load_state("networkidle")` 会抛超时异常直接中断登录流程；
- 截图前不校验二维码是否可见、是否加载完成，页面处于"微信快捷登录"模式时会截出空白图片。

新增 `_wait_qrcode_ready()`：等待二维码图片可见且 `naturalWidth > 50`（真正加载完成）；若页面默认展示"微信快捷登录"，自动点击"扫码登录"链接切换回二维码模式。

## 验证

- 用真实 `wxLogin` 流程（headless Playwright）连续验证 3 次，均在约 22 秒内生成有效二维码图片；修复前 100% 失败（白屏、无 src）。
- 截图结果为可正常扫描的登录二维码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
