### PR TITLE
fix: reduce article content storage and RSS write amplification

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -170,7 +170,7 @@ http://localhost:3000
 | `WEB_NAME` | `WeRSS微信公众号订阅助手` | 前端显示名称 |
 | `WERSS_AUTH_WEB` | `False` | 通过web方式授权 |
 | `BROWSER_TYPE` | `firefox` | 浏览器类型默认firefox |
-| `SEND_CODE` | `True` | 是否发送授权二维码通知 |
+| `SEND_CODE` | `False` | 过期通知中是否附带授权二维码（默认仅发送文字通知） |
 | `CODE_TITLE` | `WeRSS授权二维码` | 二维码通知标题 |
 | `ENABLE_JOB` | `True` | 是否启用定时任务 |
 | `AUTO_RELOAD` | `False` | 代码修改自动重启服务 |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -220,7 +220,7 @@ The following are the environment variable configurations supported in `config.y
 | `APP_NAME` | `we-mp-rss` | Application name |
 | `SERVER_NAME` | `we-mp-rss` | Server name |
 | `WEB_NAME` | `WeRSS微信公众号订阅助手` | Frontend display name |
-| `SEND_CODE` | `True` | Whether to send authorization QR code notifications |
+| `SEND_CODE` | `False` | Whether to send authorization QR code in expired notification (text-only notification by default) |
 | `CODE_TITLE` | `WeRSS授权二维码` | QR code notification title |
 | `ENABLE_JOB` | `True` | Whether to enable scheduled tasks |
 | `AUTO_RELOAD` | `False` | Auto-restart service on code changes |

--- a/apis/article.py
+++ b/apis/article.py
@@ -167,6 +167,8 @@ async def clean_orphan_articles(
                 message="清理无效文章失败"
             )
         )
+    finally:
+        session.close()
 
 
 @router.delete("/clean-old", summary="清理指定天数前的旧文章")

--- a/apis/article.py
+++ b/apis/article.py
@@ -14,7 +14,7 @@ from apis.base import format_search_kw
 from core.print import print_warning, print_info, print_error, print_success
 from core.cache import clear_cache_pattern
 from tools.fix import fix_article
-from core.article_content import sync_article_content
+from core.article_content import clean_article_content, sync_article_content
 from driver.wxarticle import WXArticleFetcher
 router = APIRouter(prefix=f"/articles", tags=["文章管理"])
 
@@ -90,10 +90,22 @@ async def _run_refresh_article_task(task_id: str, article_id: str):
         article.title = fetched.get("title") or article.title
         article.url = target_url
         article.publish_time = fetched.get("publish_time") or article.publish_time
-        article.content = fetched_content if fetched_content is not None else article.content
         if fetched_content == "DELETED":
+            article.content = ""
+            article.content_html = ""
             article.description = fetched.get("description") or article.description
         else:
+            cleaned_content = clean_article_content(fetched_content)
+            if not cleaned_content:
+                _set_refresh_task(task_id, {
+                    "task_id": task_id,
+                    "article_id": article_id,
+                    "status": "failed",
+                    "message": "文章刷新失败: 清洗后正文为空"
+                })
+                return
+            article.content = cleaned_content
+            article.content_html = cleaned_content
             article.description = fetched.get("description") or article.description
         article.pic_url = fetched.get("topic_image") or fetched.get("pic_url") or article.pic_url
         article.status = DATA_STATUS.DELETED if fetched_content == "DELETED" else DATA_STATUS.ACTIVE

--- a/apis/message_task.py
+++ b/apis/message_task.py
@@ -199,8 +199,12 @@ async def run_message_task(
             import json
             for task in tasks:
                 try:
-                    ids=json.loads(task.mps_id)
-                    count+=len(ids)
+                    # mps_id 可能为空（UI 提示"留空则对所有公众号生效"），
+                    # 通过 get_feeds() 拿实际 feed 数，与 jobs/mps.py 一致
+                    from jobs.mps import get_feeds
+                    feeds = get_feeds(task)
+                    ids = [{"id": f.id, "name": f.mp_name} for f in feeds]
+                    count += len(ids)
                     mps['count']=count
                     mps['list'].append(ids)
                 except Exception as e:

--- a/apis/message_task.py
+++ b/apis/message_task.py
@@ -1,3 +1,4 @@
+import asyncio
 from pydantic import BaseModel
 
 # 标准导入分组和顺序
@@ -148,7 +149,7 @@ async def test_message_task(
             articles=mock_articles  # type: ignore
         )
         
-        result = web_hook(test_hook, is_test=True)
+        result = await asyncio.to_thread(web_hook, test_hook, is_test=True)
         
         return success_response(
             data={

--- a/apis/rss.py
+++ b/apis/rss.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, Query, HTTPException, Request,Response
 from fastapi import status
 from fastapi.responses import Response
 from core.db import DB
-from core.rss import RSS
+from core.rss import RSS, prepare_rss_articles, should_filter_articles_without_content
 from core.models.feed import Feed
 import json
 from .base import success_response, error_response
@@ -248,12 +248,14 @@ async def get_mp_articles_source(
                 )
             )
       
-        # 查询文章列表
-        total = query.count()
-        # articles = query.order_by(Article.publish_time.desc()).limit(limit).offset(offset).all()
+        # 全文 RSS 不提前发布空正文，避免下游只导入一次后永久保留摘要版本。
+        require_content = should_filter_articles_without_content()
+        if require_content:
+            query = query.filter(Article.has_content == 1)
         if kw!="":
             query=query.filter(format_search_kw(kw))
         articles =query.order_by(Article.publish_time.desc()).limit(limit).offset(offset).all()
+        prepared_articles = prepare_rss_articles(articles, require_content=require_content)
         # 转换为RSS格式数据
         from datetime import datetime, timezone, timedelta
         cst = timezone(timedelta(hours=8))
@@ -262,7 +264,7 @@ async def get_mp_articles_source(
             "title": article.title or "",
             "link":  f"{rss_domain}/views/article/{article.id}" if cfg.get("rss.local",False) else article.url,
             "description": article.description if article.description != "" else article.title or "",
-            "content": article.content or "",
+            "content": content,
             "image": article.pic_url or "",
             "mp_name":_feed.mp_name or "",
             "updated": datetime.fromtimestamp(article.publish_time, tz=cst),
@@ -272,15 +274,15 @@ async def get_mp_articles_source(
                     "cover":_feed.mp_cover,
                     "intro":_feed.mp_intro
             }
-        } for _feed,article in articles]
+        } for _feed,article,content in prepared_articles]
         
 
         # 缓存文章内容
-        for _feed,article in articles:
+        for _feed,article,content in prepared_articles:
             content_data = {
                 "id": article.id,
                 "title": article.title,
-                "content": article.content,
+                "content": content,
                 "publish_time": article.publish_time,
                 "mp_id": article.mp_id,
                 "pic_url": article.pic_url,

--- a/apis/sys_info.py
+++ b/apis/sys_info.py
@@ -1,12 +1,15 @@
+import os
 import platform
-import time
+import sqlite3
 import sys
-import psutil
-from fastapi import APIRouter,Depends
-from typing import Dict, Any
-from core.auth import get_current_user_or_ak
+import time
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import StreamingResponse
+
+from core.auth import get_current_user, get_current_user_or_ak
 from .base import success_response, error_response
-from driver.token import wx_cfg
 from core.config import cfg
 from jobs.mps import TaskQueue
 from driver.success import getLoginInfo,getStatus
@@ -43,6 +46,12 @@ async def get_base_info() -> Dict[str, Any]:
     
 
 from core.resource import get_system_resources
+from tools.storage_maintenance import (
+    create_consistent_sqlite_backup,
+    gzip_file_chunks,
+    resolve_sqlite_path,
+)
+
 @router.get("/resources", summary="获取系统资源使用情况")
 async def system_resources(
     current_user: dict = Depends(get_current_user_or_ak)
@@ -64,6 +73,41 @@ async def system_resources(
             code=50002,
             message=f"获取系统资源失败: {str(e)}"
         )
+
+
+@router.get("/storage/backup", summary="下载 SQLite 一致性备份")
+def download_storage_backup(
+    current_user: dict = Depends(get_current_user),
+):
+    if os.getenv("WERSS_STORAGE_BACKUP_ENABLED", "").lower() != "true":
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    if current_user.get("role") != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin role required",
+        )
+
+    database_url = os.getenv("DB", "sqlite:///./data/db.db")
+    try:
+        backup_path, metadata = create_consistent_sqlite_backup(
+            resolve_sqlite_path(database_url)
+        )
+    except (OSError, ValueError, sqlite3.Error, RuntimeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to create SQLite backup: {exc}",
+        ) from exc
+
+    headers = {
+        "Content-Disposition": 'attachment; filename="werss-production.sqlite.gz"',
+        "X-SQLite-Integrity": metadata["integrity"],
+        "X-SQLite-Bytes": str(metadata["file_bytes"]),
+    }
+    return StreamingResponse(
+        gzip_file_chunks(backup_path, remove_parent_on_close=True),
+        media_type="application/gzip",
+        headers=headers,
+    )
 from core.article_lax import get_article_info, refresh_article_info
 from .ver import API_VERSION
 from core.base import VERSION as CORE_VERSION,LATEST_VERSION

--- a/config-node.yaml
+++ b/config-node.yaml
@@ -4,8 +4,8 @@ server:
    name: ${SERVER_NAME:-we-mp-rss}
    #前端显示名称
    web_name: ${WEB_NAME:-WeRSS微信公众号订阅助手}
-   #过期是否发送授权二维通知 默认True
-   send_code: ${SEND_CODE:-True}
+   #过期是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${SEND_CODE:-False}
    #二维通知标题
    code_title: ${CODE_TITLE:-WeRSS}
    #启动JOB定时任务，默认为True
@@ -16,8 +16,8 @@ server:
    threads: ${THREADS:-1}
    #通过web方式授权二维码 默认False 
    auth_web: ${WERSS_AUTH_WEB:-False}
-   #是否发送授权二维通知 默认True
-   send_code: ${WERSS_SEND_CODE:-True}
+   #是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${WERSS_SEND_CODE:-False}
 
 
 #数据库连接 例如db:  mysql+pymysql://<username>:<password>@<host>/we-rss?charset=utf8mb4

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,8 +4,8 @@ server:
    name: ${SERVER_NAME:-we-mp-rss}
    #前端显示名称
    web_name: ${WEB_NAME:-WeRSS微信公众号订阅助手}
-   #过期是否发送授权二维通知 默认True
-   send_code: ${SEND_CODE:-True}
+   #过期是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${SEND_CODE:-False}
    #二维通知标题
    code_title: ${CODE_TITLE:-WeRSS}
    #启动JOB定时任务，默认为True
@@ -16,8 +16,8 @@ server:
    threads: ${THREADS:-1}
    #通过web方式授权二维码 默认False 
    auth_web: ${WERSS_AUTH_WEB:-False}
-   #是否发送授权二维通知 默认True
-   send_code: ${WERSS_SEND_CODE:-True}
+   #是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${WERSS_SEND_CODE:-False}
    #是否启用自动刷新文章统计 默认False
    article_stats_refresh_enabled: ${ARTICLE_STATS_REFRESH_ENABLED:-False}
    # 文章统计刷新间隔 默认300秒

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -91,6 +91,8 @@ rss:
   cover: ${RSS_COVER:-}
   #是否显示全文 默认False
   full_context: ${RSS_FULL_CONTEXT:-True}
+  #全文RSS是否过滤尚未抓到正文的文章，正文补齐后会自动进入RSS
+  filter_no_content: ${RSS_FILTER_NO_CONTENT:-True}
   #是否添加封面图片 默认False
   add_cover: ${RSS_ADD_COVER:-True}
   #RSS正文是否启用 CDATA

--- a/core/article_content.py
+++ b/core/article_content.py
@@ -7,6 +7,13 @@ from core.models.base import DATA_STATUS
 from core.print import print_info, print_warning
 
 
+def clean_article_content(content: str | None) -> str:
+    """Return the compact article body used for storage and syndication."""
+    from tools.fix import fix_html
+
+    return fix_html(content or "")
+
+
 def normalize_content_mode(mode: str | None = None) -> str:
     normalized = (mode or cfg.get("gather.content_mode", "web") or "web").strip().lower()
     if normalized not in {"web", "api"}:
@@ -116,10 +123,15 @@ def sync_article_content(
             return True, mode
 
         from driver.wxarticle import Web
-        from tools.fix import fix_html
+        cleaned_content = clean_article_content(content)
+        if not cleaned_content:
+            print_warning(f"article {article.id} has no usable content after cleaning")
+            return False, mode
 
-        article.content = content
-        article.content_html = fix_html(content)
+        # Keep both columns compatible with existing readers without retaining
+        # the multi-megabyte WeChat document, scripts, and runtime payloads.
+        article.content = cleaned_content
+        article.content_html = cleaned_content
         article.show_type=article_type or article.show_type
         article.status = DATA_STATUS.ACTIVE
         article.has_content = 1

--- a/core/db.py
+++ b/core/db.py
@@ -123,6 +123,7 @@ class Db:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
     def delete_article(self,article_data:dict)->bool:
+        session = None
         try:
             art = Article(**article_data)
             if art.id: # type: ignore
@@ -136,9 +137,13 @@ class Db:
         except Exception as e:
             print_error(f"delete article:{str(e)}")
             pass      
+        finally:
+            if session is not None:
+                session.close()
         return False
      
     def add_article(self, article_data: dict,check_exist=True) -> bool:
+        session = None
         try:
             session=self.get_session()
             from datetime import datetime
@@ -194,48 +199,70 @@ class Db:
             session.add(art)
             print_info(f"Added article: {art.id}")
             sta=session.commit()
+            return True
         except Exception as e:
-            session.rollback()  # 回滚事务，确保session状态正常
+            if session:
+                session.rollback()  # 回滚事务，确保session状态正常
             if "UNIQUE" in str(e) or "Duplicate entry" in str(e):
                 print_warning(f"Article already exists: {art.id}")
             else:
                 print_error(f"Failed to add article: {e}")
             return False
-        return True    
-        
+        finally:
+            if session is not None:
+                session.close()
     def get_articles(self, id:str=None, limit:int=30, offset:int=0) -> List[Article]: # type: ignore
+        session = None
         try:
-            data = self.get_session().query(Article).limit(limit).offset(offset)
+            session = self.get_session()
+            data = session.query(Article).limit(limit).offset(offset)
             return data
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore   
+        finally:
+            if session is not None:
+                session.close()
              
     def get_all_mps(self) -> List[Feed]:
         """Get all Feed records"""
+        session = None
         try:
-            return self.get_session().query(Feed).all()
+            session = self.get_session()
+            return session.query(Feed).filter(Feed.status == 1).all()
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore
+        finally:
+            if session is not None:
+                session.close()
             
     def get_mps_list(self, mp_ids:str) -> List[Feed]:
+        session = None
         try:
             ids=mp_ids.split(',')
-            data =  self.get_session().query(Feed).filter(Feed.id.in_(ids)).all()
+            session = self.get_session()
+            data = session.query(Feed).filter(Feed.id.in_(ids)).all()
             return data
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore
+        finally:
+            if session is not None:
+                session.close()
     def get_mps(self, mp_id:str) -> Optional[Feed]:
+        session = None
         try:
             ids=mp_id.split(',')
-            data =  self.get_session().query(Feed).filter_by(id= mp_id).first()
+            session = self.get_session()
+            data = session.query(Feed).filter_by(id= mp_id).first()
             return data
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore
-
+        finally:
+            if session is not None:
+                session.close()
     def get_faker_id(self, mp_id:str):
         data = self.get_mps(mp_id)
         return data.faker_id # type: ignore

--- a/core/db.py
+++ b/core/db.py
@@ -69,6 +69,9 @@ class Db:
                 @event.listens_for(self.engine, "connect")
                 def set_sqlite_text_factory(dbapi_conn, connection_record):
                     # 将无效 UTF-8 字符替换为 �
+                    dbapi_conn.execute("PRAGMA journal_mode=WAL")
+                    dbapi_conn.execute("PRAGMA busy_timeout=10000")
+                    dbapi_conn.execute("PRAGMA synchronous=NORMAL")
                     dbapi_conn.text_factory = lambda x: x.decode('utf-8', errors='replace')
             
             self.session_factory=self.get_session_factory()
@@ -229,7 +232,7 @@ class Db:
         session = None
         try:
             session = self.get_session()
-            return session.query(Feed).filter(Feed.status == 1).all()
+            return session.query(Feed).filter(Feed.status == 1, Feed.faker_id != "MP_WXS_FEATURED_ARTICLES").all()
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore

--- a/core/db.py
+++ b/core/db.py
@@ -166,11 +166,13 @@ class Db:
                     and art.title==existing_article.title: # type: ignore
                         return False
                     
-                    if art.content is None:
-                        from tools.fix import fix_html
-                        art.content_html = fix_html(art.content) # type: ignore
+                    if art.content is not None:
+                        from core.article_content import clean_article_content
+                        cleaned_content = clean_article_content(art.content) # type: ignore
+                        art.content = cleaned_content or None # type: ignore
+                        art.content_html = cleaned_content or None # type: ignore
                         # 设置 has_content 字段
-                        art.has_content = 1 if (art.content and art.content.strip()) else 0 # type: ignore
+                        art.has_content = 1 if cleaned_content else 0 # type: ignore
                     session.merge(art)  # 使用 merge 来更新现有记录
                     session.commit()
                     print_warning(f"Article already exists: {art.id}")
@@ -193,8 +195,10 @@ class Db:
             art.content_html = sanitize_utf8(art.content_html) if art.content_html else None # type: ignore
 
             if art.content is not None:
-                from tools.fix import fix_html
-                art.content_html = fix_html(art.content) # type: ignore
+                from core.article_content import clean_article_content
+                cleaned_content = clean_article_content(art.content) # type: ignore
+                art.content = cleaned_content or None # type: ignore
+                art.content_html = cleaned_content or None # type: ignore
 
             # 设置 has_content 字段
             art.has_content = 1 if (art.content and art.content.strip()) else 0 # type: ignore

--- a/core/notice/custom.py
+++ b/core/notice/custom.py
@@ -20,7 +20,8 @@ def send_custom_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/dingtalk.py
+++ b/core/notice/dingtalk.py
@@ -27,7 +27,8 @@ def send_dingtalk_message(webhook_url, title, text, is_at_all=False, at_mobiles=
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/feishu.py
+++ b/core/notice/feishu.py
@@ -40,7 +40,8 @@ def send_feishu_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/wechat.py
+++ b/core/notice/wechat.py
@@ -24,7 +24,8 @@ def send_wechat_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/queue/queue.py
+++ b/core/queue/queue.py
@@ -368,9 +368,16 @@ class TaskQueueManager:
                 max_retries=max_retries
             ))
             
-            # 保存到 Redis
-            self._save_pending_to_redis()
-            self._save_status_to_redis()
+            # 优化：只追加新任务到 Redis，而不是全量重写
+            redis_client = _get_redis()
+            if redis_client:
+                try:
+                    new_item = self._pending_items[-1].to_dict()
+                    redis_client.rpush(self._redis_keys['pending'], json.dumps(new_item, ensure_ascii=False))
+                    # 只更新计数，不保存完整状态
+                    redis_client.hincrby(self._redis_keys['status'], 'pending_count', 1)
+                except Exception as e:
+                    print_error(f"追加任务到 Redis 失败: {e}")
             
             # 标记需要广播，但不在这里执行（避免在锁内进行异步操作）
             broadcast_needed = True

--- a/core/queue/queue.py
+++ b/core/queue/queue.py
@@ -6,6 +6,7 @@ import json
 from typing import Callable, Any, Optional
 from datetime import datetime
 from dataclasses import dataclass, field, asdict
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from core.print import print_error, print_info, print_warning, print_success
 
 # Redis 键前缀 - 主队列（文章列表采集）
@@ -457,7 +458,15 @@ class TaskQueueManager:
                         try:
                             # 记录任务开始时间
                             start_time = time.time()
-                            task(*args, **kwargs)
+                            task_executor = ThreadPoolExecutor(max_workers=1)
+                            try:
+                                future = task_executor.submit(task, *args, **kwargs)
+                                future.result(timeout=600)
+                            except FutureTimeoutError:
+                                print_error("Task [{}] execution timeout (10 min)".format(task_name))
+                                raise Exception("Task timed out after 600s")
+                            finally:
+                                task_executor.shutdown(wait=False)
                             # 记录任务执行时间
                             duration = time.time() - start_time
                             

--- a/core/resource.py
+++ b/core/resource.py
@@ -1,4 +1,11 @@
+import os
+import sqlite3
+from pathlib import Path
+
 import psutil
+
+from tools.storage_maintenance import resolve_sqlite_path, storage_report
+
 # Desc: 资源信息
 # Date: 2021-04-29 15:59
 # Author: Rachel
@@ -29,6 +36,19 @@ def get_system_resources():
     def to_gb(bytes_value):
             return round(bytes_value / (1024 ** 3), 2)
         
+    database_url = os.getenv("DB", "sqlite:///./data/db.db")
+    data_dir = Path(os.getenv("WERSS_DATA_DIR", "./data"))
+    try:
+        persistent_storage = storage_report(
+            data_dir.resolve(),
+            resolve_sqlite_path(database_url),
+        )
+    except (OSError, ValueError, sqlite3.Error):
+        persistent_storage = {
+            "path": str(data_dir),
+            "available": False,
+        }
+
     resources_info = {
             'cpu': {
                 'percent': cpu_percent,
@@ -51,6 +71,7 @@ def get_system_resources():
                 'cpu_percent': process_cpu_percent,
                 'memory_used': to_gb(process_mem_info.rss),
                 'memory_percent': current_process.memory_percent()
-            }
+            },
+            'persistent_storage': persistent_storage,
         }
     return resources_info

--- a/core/rss.py
+++ b/core/rss.py
@@ -2,7 +2,39 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 import os
 import json
+from core.article_content import clean_article_content
 from core.content_format import format_content
+
+
+def select_article_content(article) -> str:
+    """Return cleaned content without exposing a legacy raw WeChat document."""
+    cleaned_content = (getattr(article, "content_html", None) or "").strip()
+    if cleaned_content:
+        return cleaned_content
+
+    return clean_article_content(getattr(article, "content", None))
+
+
+def should_filter_articles_without_content() -> bool:
+    """Filter incomplete items only when consumers requested full content."""
+    from core.config import cfg
+
+    return bool(cfg.get("rss.full_context", False)) and bool(
+        cfg.get("rss.filter_no_content", True)
+    )
+
+
+def prepare_rss_articles(articles, require_content: bool):
+    """Attach selected content and omit incomplete articles when requested."""
+    prepared = []
+    for feed, article in articles:
+        content = select_article_content(article)
+        if require_content and not content.strip():
+            continue
+        prepared.append((feed, article, content))
+    return prepared
+
+
 class RSS:
     cache_dir = os.path.normpath("data/cache/rss")
     content_cache_dir = os.path.normpath("data/cache/content")

--- a/core/rss.py
+++ b/core/rss.py
@@ -15,6 +15,34 @@ def select_article_content(article) -> str:
     return clean_article_content(getattr(article, "content", None))
 
 
+def is_usable_rss_content(content: str | None) -> bool:
+    """Reject historical WeChat error/shell pages from full-content feeds."""
+    if not (content or "").strip():
+        return False
+
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(content, "html.parser")
+    text = soup.get_text(" ", strip=True)
+    hard_error_markers = (
+        "未知错误，请稍后再试",
+        "你暂无权限查看此页面内容",
+        "当前环境异常，完成验证后即可继续访问",
+    )
+    if any(marker in text for marker in hard_error_markers):
+        return False
+
+    has_wechat_shell = (
+        "微信扫一扫可打开此内容" in text
+        and "使用完整服务" in text
+    )
+    meaningful_length = sum(character.isalnum() for character in text)
+    if has_wechat_shell and meaningful_length < 300:
+        return False
+
+    return bool(text) or soup.find(["img", "video", "audio", "iframe"]) is not None
+
+
 def should_filter_articles_without_content() -> bool:
     """Filter incomplete items only when consumers requested full content."""
     from core.config import cfg
@@ -29,7 +57,7 @@ def prepare_rss_articles(articles, require_content: bool):
     prepared = []
     for feed, article in articles:
         content = select_article_content(article)
-        if require_content and not content.strip():
+        if require_content and not is_usable_rss_content(content):
             continue
         prepared.append((feed, article, content))
     return prepared

--- a/core/wx/base.py
+++ b/core/wx/base.py
@@ -320,11 +320,10 @@ class WxGather:
         if code=="Invalid Session":
             # from core.queue import TaskQueue
             # TaskQueue.clear_queue()  # 已注释：避免微信认证失效时清空队列
-            if cfg.get("server.send_code")=="True":
-                from jobs.failauth import send_wx_code
-                import threading
-                setStatus(False)
-                threading.Thread(target=send_wx_code,args=(f"公众号平台登录失效,请重新登录",)).start()
+            from jobs.failauth import send_wx_code
+            import threading
+            setStatus(False)
+            threading.Thread(target=send_wx_code,args=(f"公众号平台登录失效,请重新登录",)).start()
             # send_wx_code(f"公众号平台登录失效,请重新登录")
             raise Exception(error)
         # raise Exception(error)

--- a/core/wx/model/api.py
+++ b/core/wx/model/api.py
@@ -21,8 +21,7 @@ class MpsApi(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page=0,MaxPage:int=1,interval=10,Gather_Content=True,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-             Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"API获取模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsg"

--- a/core/wx/model/app.py
+++ b/core/wx/model/app.py
@@ -26,8 +26,7 @@ class MpsAppMsg(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-            Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"APP浏览器模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsgpublish"

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -57,7 +57,7 @@ class MpsWeb(WxGather):
             time.sleep(random.randint(0,interval))
             try:
                 headers = self.fix_header(url)
-                resp = session.get(url, headers=headers, params = params, verify=False)
+                resp = session.get(url, headers=headers, params = params, verify=False, timeout=(10, 30))
                 
                 msg = resp.json()
                 self._cookies =resp.cookies

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -26,8 +26,7 @@ class MpsWeb(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str='',Mps_id:str='',Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-            Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"Web浏览器模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsgpublish"

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -69,6 +69,15 @@ class MpsWeb(WxGather):
                 if msg['base_resp']['ret'] == 200003:
                     super().Error("Invalid Session, stop at {}".format(str(begin)),code="Invalid Session")
                     break
+                # 处理200002错误：参数无效
+                if msg['base_resp']['ret'] == 200002:
+                    super().Error("Invalid arguments, stop at {}".format(str(begin)), code="Invalid Arguments")
+                    # 设置feed状态为0并继续下一个任务
+                    self._set_feed_status(Mps_id, 0)
+                    # 不break，而是return，这样可以继续下一个任务
+                    super().Item_Over(item={"mps_id":Mps_id,"mps_title":Mps_title},CallBack=Item_Over_CallBack)
+                    super().Over(CallBack=Over_CallBack)
+                    return
                 if msg['base_resp']['ret'] != 0:
                     super().Error("错误原因:{}:代码:{}".format(msg['base_resp']['err_msg'],msg['base_resp']['ret']),code=msg['base_resp']['err_msg'])
                     break    
@@ -112,3 +121,19 @@ class MpsWeb(WxGather):
                 super().Item_Over(item={"mps_id":Mps_id,"mps_title":Mps_title},CallBack=Item_Over_CallBack)
         super().Over(CallBack=Over_CallBack)
         pass
+    # 新增辅助方法用于设置feed状态
+    def _set_feed_status(self, feed_id: str, status: int):
+        """设置feed状态"""
+        try:
+            from core.db import DB
+            from core.models import Feed
+            session = DB.get_session()
+            feed = session.query(Feed).filter(Feed.id == feed_id).first()
+            if feed:
+                feed.status = status
+                session.commit()
+                print(f"已将feed {feed_id} 的状态设置为 {status}")
+            else:
+                print(f"未找到feed {feed_id}")
+        except Exception as e:
+            logger.error(f"设置feed状态失败: {e}")

--- a/driver/anti_crawler_config.py
+++ b/driver/anti_crawler_config.py
@@ -30,8 +30,7 @@ class AntiCrawlerConfig:
             "zh-CN,zh;q=0.9,en;q=0.8",
             "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2",
             "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7"
-        ],
-        'cache_control': ["no-cache", "max-age=0", "no-store"]
+        ]
     }
     
     # 时区配置
@@ -94,8 +93,11 @@ class AntiCrawlerConfig:
             "Accept": random.choice(self.HEADERS['accept']),
             "Accept-Language": random.choice(self.HEADERS['accept_language']),
             "Accept-Encoding": "gzip, deflate, br",
-            "Cache-Control": random.choice(self.HEADERS['cache_control']),
-            "Upgrade-Insecure-Requests": "1",
+            # 注意：不能设置 Cache-Control 和 Upgrade-Insecure-Requests。
+            # extra_http_headers 会作用于页面发出的所有请求（包括XHR），
+            # 而真实浏览器只在页面导航请求上带这两个头；
+            # 带上后 mp.weixin.qq.com 登录页初始化失败，
+            # #app 一直保持 visibility:hidden，登录二维码无法加载
             "Sec-Fetch-Dest": "document",
             "Sec-Fetch-Mode": "navigate",
             "Sec-Fetch-Site": "none",

--- a/driver/chrome_path.py
+++ b/driver/chrome_path.py
@@ -1,0 +1,52 @@
+"""
+跨平台解析本地 Chromium 内核浏览器（Chrome / Edge / Chromium）可执行文件路径。
+
+设计目标：
+- 不写死任何机器专属绝对路径（如某台 Windows 的 D:\\Tools\\...）。
+- 跨平台：Win11 / Docker-Linux / macOS 均可用。
+- 默认“不启用”：解析不到时返回 None，由调用方回退到 Playwright 自带浏览器，
+  从而保持上游默认行为（默认 webkit）完全不变，Docker/Linux 零回归。
+
+解析优先级：
+  1. 环境变量 CHROME_EXECUTABLE_PATH（跨平台、最高优先级，用户显式指定）
+  2. 当前操作系统的“标准安装位置”自动发现（仅当文件确实存在时才采用）
+  3. 都没有 -> 返回 None
+"""
+import os
+import sys
+
+# 仅收录各平台“标准”安装位置；不含任何机器专属路径。
+# 找不到时列表自然跳过，返回 None（调用方回退自带浏览器）。
+_CANDIDATES = {
+    "win32": [
+        os.path.expandvars(r"%ProgramFiles%\Google\Chrome\Application\chrome.exe"),
+        os.path.expandvars(r"%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe"),
+        os.path.expandvars(r"%ProgramFiles%\Microsoft\Edge\Application\msedge.exe"),
+        os.path.expandvars(r"%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe"),
+    ],
+    "linux": [
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser",
+    ],
+    "darwin": [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    ],
+}
+
+
+def get_chrome_executable_path() -> "str | None":
+    """返回可用的 Chromium 内核浏览器可执行文件路径；无则返回 None。
+
+    返回 None 时，调用方应保持原有浏览器类型（如上游默认的 webkit），
+    由 Playwright 启动其自带浏览器，确保 Docker/Linux 默认行为不变。
+    """
+    env = os.environ.get("CHROME_EXECUTABLE_PATH")
+    if env and os.path.exists(env):
+        return env
+    for cand in _CANDIDATES.get(sys.platform, []):
+        if cand and os.path.exists(cand):
+            return cand
+    return None

--- a/driver/playwright_driver.py
+++ b/driver/playwright_driver.py
@@ -18,6 +18,7 @@ if sys.platform == 'win32':
 
 from core.print import print_error, print_info, print_warning
 from driver.anti_crawler_config import AntiCrawlerConfig
+from driver.chrome_path import get_chrome_executable_path
 
 @dataclass
 class Metrics:
@@ -54,7 +55,8 @@ class PlaywrightController:
                  proxy_url: Optional[str] = "",
                  user_agent: Optional[str] = None,
                  debug: bool = False,
-                 mobile_mode: bool = False):
+                 mobile_mode: bool = False,
+                 apply_anti_crawler: bool = True):
         """
         初始化异步控制器
 
@@ -72,6 +74,11 @@ class PlaywrightController:
         self.proxy_url = proxy_url
         self.debug = debug
         self.mobile_mode = mobile_mode
+        # 是否应用反爬虫注入（extra_http_headers + 反检测脚本）。
+        # 反爬头含 Cache-Control / Sec-Fetch-* 等非 CORS 安全头，会触发跨域预检，
+        # 导致部分站点（如微信公众平台登录页）自身 JS 资源加载失败、二维码无法渲染。
+        # 微信登录等场景需退化为普通浏览器，故提供关闭开关。
+        self.apply_anti_crawler = apply_anti_crawler
 
         # 反爬虫配置实例
         self.anti_crawler_config = AntiCrawlerConfig()
@@ -119,6 +126,15 @@ class PlaywrightController:
             # 启动 Playwright
             self._playwright = await async_playwright().start()
 
+            # ===== 本地 Chrome 支持（可选，避免强制 playwright install 下载浏览器）=====
+            # 仅当通过环境变量 CHROME_EXECUTABLE_PATH 显式指定（或自动发现到本机标准安装的
+            # Chromium 内核浏览器）时才启用；否则保持上游默认浏览器（默认 webkit，由 Playwright 自带），
+            # 跨平台可移植，Docker/Linux 默认行为不受影响。
+            CHROME_PATH = get_chrome_executable_path()
+            if CHROME_PATH:
+                self.browser_type = "chromium"
+                print_info(f"使用本地 Chrome: {CHROME_PATH}（跳过 Playwright 浏览器下载）")
+
             # 选择浏览器类型
             browser_launcher = getattr(self._playwright, self.browser_type)
 
@@ -138,6 +154,9 @@ class PlaywrightController:
                     "--disable-dev-shm-usage",
                     "--no-sandbox",
                 ]
+                # 使用本地 Chrome 可执行文件，避免下载 Playwright 浏览器
+                if CHROME_PATH:
+                    launch_options["executable_path"] = CHROME_PATH
 
             # 添加代理
             if self.proxy_url:
@@ -157,8 +176,8 @@ class PlaywrightController:
                 "timezone_id": "Asia/Shanghai",
             }
 
-            # 应用额外的HTTP头
-            if "extra_http_headers" in anti_config:
+            # 应用额外的HTTP头（反爬注入可能破坏跨域资源加载，关闭时跳过）
+            if self.apply_anti_crawler and "extra_http_headers" in anti_config:
                 context_options["extra_http_headers"] = anti_config["extra_http_headers"]
 
             # 应用其他可选配置
@@ -171,8 +190,9 @@ class PlaywrightController:
             # 创建页面
             self._page = await self._context.new_page()
 
-            # ========== 核心改造：注入反检测脚本 ==========
-            await self._apply_anti_crawler_scripts(self._page)
+            # ========== 核心改造：注入反检测脚本（关闭反爬时跳过）==========
+            if self.apply_anti_crawler:
+                await self._apply_anti_crawler_scripts(self._page)
 
             # 记录启动时间
             self.metrics.browser_startup_time = time.time() - start_time

--- a/driver/wx.py
+++ b/driver/wx.py
@@ -436,6 +436,38 @@ class Wx:
                 except Exception as e:
                     print(f"二维码图片获取失败: {str(e)}")
         return self.isLock
+    async def _wait_qrcode_ready(self, page, qr_tag, timeout=30):
+        """等待登录二维码图片加载完成（异步）
+
+        新版登录页可能默认展示"微信快捷登录"（open.weixin.qq.com iframe），
+        此时经典二维码处于隐藏状态且src为空，直接截图会得到空白图片或超时。
+        检测到该情况时点击"扫码登录"链接切换回二维码登录，
+        再等待二维码图片可见且真正加载完成。
+        """
+        import asyncio
+
+        deadline = time.time() + timeout
+        switch_clicked = False
+        while time.time() < deadline:
+            ready = await page.evaluate(
+                """(sel) => {
+                    const img = document.querySelector(sel);
+                    if (!img) return false;
+                    const style = window.getComputedStyle(img);
+                    if (style.display === 'none' || style.visibility === 'hidden') return false;
+                    return !!img.src && img.complete && img.naturalWidth > 50;
+                }""", qr_tag)
+            if ready:
+                return True
+            if not switch_clicked:
+                switch_link = page.locator("a.login__type__container__link_text", has_text="扫码登录")
+                if await switch_link.count() > 0 and await switch_link.first.is_visible():
+                    print_info("检测到快捷登录页面，切换到扫码登录...")
+                    await switch_link.first.click()
+                    switch_clicked = True
+            await asyncio.sleep(0.5)
+        return False
+
     async def wxLogin(self, CallBack=None, NeedExit=True):
         """
         微信公众平台登录流程（异步）：
@@ -474,11 +506,20 @@ class Wx:
             page = driver.page
 
             # 等待页面完全加载
+            # 新版登录页存在持续的轮询请求，networkidle可能永远不触发，
+            # 超时不视为错误，由后续二维码加载检测兜底
             print_info("正在加载登录页面...")
-            await page.wait_for_load_state("networkidle")
+            try:
+                await page.wait_for_load_state("networkidle", timeout=10000)
+            except Exception:
+                pass
 
             # 定位二维码区域
             qr_tag = ".login__type__container__scan__qrcode"
+            # 新版登录页可能默认展示"微信快捷登录"，二维码被隐藏或src为空，
+            # 需要先切换回扫码登录并等待二维码图片真正加载完成
+            if not await self._wait_qrcode_ready(page, qr_tag):
+                raise Exception("二维码加载超时，请重试")
             # 获取二维码图片URL
             qrcode = await page.query_selector(qr_tag)
             code_src = await qrcode.get_attribute("src")
@@ -503,7 +544,10 @@ class Wx:
                 if self.WX_HOME in current_url:
                     print(f"登录成功，正在获取cookie和token...")
             page.on('framenavigated', handle_frame_navigated)
-            await page.wait_for_event("framenavigated", timeout=5*60 * 1000)
+            # 只等待主页面跳转到公众平台首页，
+            # 不能用 wait_for_event("framenavigated")：页面内的快捷登录iframe
+            # 加载时也会触发该事件，导致未扫码就误判为登录成功
+            await page.wait_for_url(lambda url: "cgi-bin/home" in url, timeout=5*60 * 1000)
 
             from .success import setStatus
             with self._login_lock:

--- a/jobs/failauth.py
+++ b/jobs/failauth.py
@@ -1,4 +1,4 @@
-from core.print import print_warning
+from core.print import print_warning, print_info
 from driver.base import WX_API
 from core.config import cfg
 from jobs.notice import sys_notice
@@ -6,22 +6,59 @@ from driver.success import Success
 from tools.base64_tools import image_to_base64
 import time
 
-def send_wx_code(title:str="",url:str=""):
-    if cfg.get("server.send_code",False):
-        WX_API.GetCode(Notice=CallBackNotice,CallBack=Success)
-    pass
-def CallBackNotice(data=None,ext_data=None):
-        if data is not None:
-            print_warning(data)
-            return 
-        img_path=WX_API.QRcode()['code']
-        rss_domain=str(cfg.get("rss.base_url",""))
-        url=rss_domain+str(img_path)
-        url=image_to_base64("./static/wx_qrcode.png")
-        text=f"- 服务名：{cfg.get('server.name','')}\n"
-        text+=f"- 发送时间： {time.strftime('%Y-%m-%d %H:%M:%S',time.localtime(time.time()))}"
-        if WX_API.GetHasCode():
-            text+=f"![描述]({url})"
-            # text+=f"<img src='{url}' width='100' height='100'/>"
-            text+=f"\n- 请使用微信扫描二维码进行授权"
-        sys_notice(text, str(cfg.get("server.code_title","WeRss授权过期,扫码授权")))
+
+def send_wx_code(title: str = "", url: str = ""):
+    """发送微信授权过期通知
+
+    始终发送过期通知。当 send_code=True 时，尝试获取二维码并附带在通知中；
+    当 send_code=False 时，只发送文字通知（不含二维码）。
+    """
+    # 始终发送过期通知（不依赖 send_code 配置）
+    text = f"- 服务名：{cfg.get('server.name', '')}\n"
+    text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}\n"
+    if title:
+        text += f"- 原因：{title}\n"
+
+    notice_title = str(cfg.get("server.code_title", "WeRss授权过期,扫码授权"))
+
+    if cfg.get("server.send_code", False):
+        # send_code=True: 尝试获取二维码，通过回调发送含二维码的通知
+        WX_API.GetCode(Notice=CallBackNotice, CallBack=Success)
+    else:
+        # send_code=False: 直接发送不含二维码的文字通知
+        text += "- 请手动访问系统进行扫码登录"
+        try:
+            sys_notice(text=text, title=notice_title)
+            print_info(f"已发送授权过期通知(无二维码): {notice_title}")
+        except Exception as e:
+            print_warning(f"发送授权过期通知失败: {e}")
+
+
+def CallBackNotice(data=None, ext_data=None):
+    """获取二维码过程中的回调通知"""
+    if data is not None:
+        print_warning(data)
+        # 获取二维码出错时，发送不含二维码的通知提醒用户手动登录
+        text = f"- 服务名：{cfg.get('server.name', '')}\n"
+        text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}\n"
+        text += f"- 获取二维码失败：{data}\n"
+        text += "- 请手动访问系统进行扫码登录"
+        try:
+            sys_notice(
+                text=text,
+                title=str(cfg.get("server.code_title", "WeRss授权过期"))
+            )
+        except Exception as e:
+            print_warning(f"发送二维码获取失败通知失败: {e}")
+        return
+
+    img_path = WX_API.QRcode()['code']
+    rss_domain = str(cfg.get("rss.base_url", ""))
+    url = rss_domain + str(img_path)
+    url = image_to_base64("./static/wx_qrcode.png")
+    text = f"- 服务名：{cfg.get('server.name', '')}\n"
+    text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}"
+    if WX_API.GetHasCode():
+        text += f"![描述]({url})"
+        text += f"\n- 请使用微信扫描二维码进行授权"
+    sys_notice(text, str(cfg.get("server.code_title", "WeRss授权过期,扫码授权")))

--- a/jobs/fetch_no_article.py
+++ b/jobs/fetch_no_article.py
@@ -53,6 +53,9 @@ def fetch_articles_without_content():
                         print_error(f"获取文章 {article.title} 内容已被发布者删除")
                     else:
                         print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:8001/views/article/{article.id}")
+                        # 成功获取内容后，恢复原始状态（通常为 ACTIVE），释放 FETCHING 锁
+                        article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
+                        session.commit()
                 else:
                     # 获取失败，恢复状态以便后续重试
                     article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)

--- a/jobs/fetch_no_article.py
+++ b/jobs/fetch_no_article.py
@@ -52,7 +52,7 @@ def fetch_articles_without_content():
                     if article.status == DATA_STATUS.DELETED:
                         print_error(f"获取文章 {article.title} 内容已被发布者删除")
                     else:
-                        print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:8001/views/article/{article.id}")
+                        print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:{cfg.get('port', 8001)}/views/article/{article.id}")
                         # 成功获取内容后，恢复原始状态（通常为 ACTIVE），释放 FETCHING 锁
                         article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
                         session.commit()

--- a/jobs/mps.py
+++ b/jobs/mps.py
@@ -232,7 +232,7 @@ def add_job(feeds:list[Feed]=None,task:MessageTask=None,isTest=False):
     pass
 import json
 def get_feeds(task:MessageTask=None):
-     mps = json.loads(task.mps_id)
+     mps = json.loads(task.mps_id) if task.mps_id else []
      ids=",".join([item["id"]for item in mps])
      mps=wx_db.get_mps_list(ids)
      if len(mps)==0:

--- a/jobs/webhook.py
+++ b/jobs/webhook.py
@@ -196,7 +196,8 @@ def call_webhook(hook: MessageWebHook, is_test: bool = False) -> str:
             hook.task.web_hook_url,
             data=payload,
             headers=headers,
-            cookies=cookies
+            cookies=cookies,
+            timeout=30
         )
         response.raise_for_status()
         return "Webhook调用成功"

--- a/start.sh
+++ b/start.sh
@@ -8,6 +8,11 @@ plant="${PLANT_PATH}_${plantform}"
 source /app/environment.sh
 source "$plant/bin/activate"
 
+# Optional one-shot migration for reclaiming legacy raw article pages.
+if ! python3 tools/storage_maintenance.py; then
+    echo "Storage maintenance failed; preserving the existing database and continuing startup." >&2
+fi
+
 # 启动 Xvfb（如果需要非 headless 模式）
 if [ "$HEADLESS" != "true" ] || [ "$ENABLE_XVFB" = "true" ]; then
     echo "启动 Xvfb 虚拟 X Server..."

--- a/start.sh
+++ b/start.sh
@@ -9,7 +9,7 @@ source /app/environment.sh
 source "$plant/bin/activate"
 
 # Optional one-shot migration for reclaiming legacy raw article pages.
-if ! python3 tools/storage_maintenance.py; then
+if ! python3 -m tools.storage_maintenance; then
     echo "Storage maintenance failed; preserving the existing database and continuing startup." >&2
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -10,6 +10,10 @@ source "$plant/bin/activate"
 
 # Optional one-shot migration for reclaiming legacy raw article pages.
 if ! python3 -m tools.storage_maintenance; then
+    if [ "${WERSS_STORAGE_LOW_SPACE_MODE:-false}" = "true" ]; then
+        echo "Low-space storage maintenance failed; refusing to start with a potentially partial database." >&2
+        exit 1
+    fi
     echo "Storage maintenance failed; preserving the existing database and continuing startup." >&2
 fi
 

--- a/tests/test_clean_article_content.py
+++ b/tests/test_clean_article_content.py
@@ -95,6 +95,24 @@ class CleanArticleContentTest(unittest.TestCase):
 
         self.assertEqual(prepared, [("feed", incomplete, "")])
 
+    @patch("core.rss.clean_article_content", side_effect=lambda content: content or "")
+    def test_full_content_feed_omits_wechat_shell_page(self, _clean_content):
+        shell_page = SimpleNamespace(
+            content=(
+                "<p>知道了 取消 允许</p>"
+                "<p>微信扫一扫可打开此内容，使用完整服务</p>"
+                "<p>视频 小程序 赞 在看 分享 留言 收藏 听过</p>"
+            ),
+            content_html=None,
+        )
+
+        prepared = prepare_rss_articles(
+            [("feed", shell_page)],
+            require_content=True,
+        )
+
+        self.assertEqual(prepared, [])
+
     def test_content_cache_receives_compact_body(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             rss = RSS(name="test", cache_dir=temp_dir)

--- a/tests/test_clean_article_content.py
+++ b/tests/test_clean_article_content.py
@@ -1,0 +1,110 @@
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from core.article_content import clean_article_content, sync_article_content
+from core.rss import RSS, prepare_rss_articles, select_article_content
+
+
+class FakeSession:
+    def __init__(self):
+        self.commit_count = 0
+
+    def commit(self):
+        self.commit_count += 1
+
+    def refresh(self, _article):
+        return None
+
+    def rollback(self):
+        return None
+
+
+class CleanArticleContentTest(unittest.TestCase):
+    @patch("tools.fix.fix_html", return_value="<p>clean body</p>")
+    def test_clean_article_content_uses_normalized_body(self, fix_html):
+        result = clean_article_content("<html><script>large payload</script></html>")
+
+        self.assertEqual(result, "<p>clean body</p>")
+        fix_html.assert_called_once()
+
+    @patch("tools.fix.fix_html", return_value="<p>clean body</p>")
+    @patch(
+        "core.article_content.fetch_article_content",
+        return_value=("<html><script>large payload</script></html>", "web", ""),
+    )
+    def test_sync_stores_only_cleaned_content(self, _fetch, _fix_html):
+        article = SimpleNamespace(
+            id="article-1",
+            mp_id="feed-1",
+            url="https://example.com/article",
+            content="",
+            content_html="",
+            description="existing description",
+            has_content=0,
+            fix_fail_count=2,
+            show_type=0,
+            status=1,
+        )
+        session = FakeSession()
+
+        updated, mode = sync_article_content(session, article)
+
+        self.assertTrue(updated)
+        self.assertEqual(mode, "web")
+        self.assertEqual(article.content, "<p>clean body</p>")
+        self.assertEqual(article.content_html, "<p>clean body</p>")
+        self.assertEqual(article.has_content, 1)
+        self.assertEqual(article.fix_fail_count, 0)
+        self.assertEqual(session.commit_count, 1)
+
+    def test_rss_prefers_cleaned_content_for_existing_rows(self):
+        article = SimpleNamespace(
+            content="<html><script>large payload</script></html>",
+            content_html="<p>clean body</p>",
+        )
+
+        self.assertEqual(select_article_content(article), "<p>clean body</p>")
+
+    @patch("core.rss.clean_article_content", return_value="<p>clean legacy body</p>")
+    def test_rss_cleans_legacy_content_before_fallback(self, clean_content):
+        article = SimpleNamespace(
+            content="<!DOCTYPE html><script>large payload</script>",
+            content_html=None,
+        )
+
+        self.assertEqual(select_article_content(article), "<p>clean legacy body</p>")
+        clean_content.assert_called_once_with(article.content)
+
+    @patch("core.rss.clean_article_content", side_effect=lambda content: content or "")
+    def test_full_content_feed_omits_incomplete_articles(self, _clean_content):
+        complete = SimpleNamespace(content="<p>body</p>", content_html=None)
+        incomplete = SimpleNamespace(content="", content_html=None)
+        articles = [("feed", complete), ("feed", incomplete)]
+
+        prepared = prepare_rss_articles(articles, require_content=True)
+
+        self.assertEqual(prepared, [("feed", complete, "<p>body</p>")])
+
+    @patch("core.rss.clean_article_content", side_effect=lambda content: content or "")
+    def test_summary_feed_keeps_incomplete_articles(self, _clean_content):
+        incomplete = SimpleNamespace(content="", content_html=None)
+
+        prepared = prepare_rss_articles([("feed", incomplete)], require_content=False)
+
+        self.assertEqual(prepared, [("feed", incomplete, "")])
+
+    def test_content_cache_receives_compact_body(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            rss = RSS(name="test", cache_dir=temp_dir)
+            rss.content_cache_dir = temp_dir
+            rss.cache_content("article-1", {"content": "<p>clean body</p>"})
+
+            cached = rss.get_cached_content("article-1")
+
+        self.assertEqual(cached["content"], "<p>clean body</p>")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_storage_maintenance.py
+++ b/tests/test_storage_maintenance.py
@@ -1,3 +1,4 @@
+import gzip
 import sqlite3
 import tempfile
 import unittest
@@ -7,6 +8,8 @@ from unittest.mock import patch
 from tools.storage_maintenance import (
     clear_regenerable_caches,
     compact_sqlite_database,
+    create_consistent_sqlite_backup,
+    gzip_file_chunks,
     run_storage_maintenance,
     sqlite_metrics,
 )
@@ -119,6 +122,30 @@ class StorageMaintenanceTests(unittest.TestCase):
             self.assertEqual(first["status"], "completed")
             self.assertEqual(second["status"], "skipped")
             self.assertTrue(sqlite_metrics(db_path)["exists"])
+
+    def test_streamed_backup_is_consistent_and_removes_temporary_copy(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            db_path = self.create_database(root)
+            backup_path, metadata = create_consistent_sqlite_backup(db_path, root)
+
+            compressed = b"".join(
+                gzip_file_chunks(backup_path, remove_parent_on_close=True)
+            )
+            restored_path = root / "restored.db"
+            restored_path.write_bytes(gzip.decompress(compressed))
+
+            self.assertEqual(metadata["integrity"], "ok")
+            self.assertFalse(backup_path.parent.exists())
+            with sqlite3.connect(restored_path) as connection:
+                self.assertEqual(
+                    connection.execute("PRAGMA integrity_check").fetchone()[0],
+                    "ok",
+                )
+                self.assertEqual(
+                    connection.execute("SELECT COUNT(*) FROM articles").fetchone()[0],
+                    3,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_storage_maintenance.py
+++ b/tests/test_storage_maintenance.py
@@ -16,6 +16,14 @@ from tools.storage_maintenance import (
 
 
 class StorageMaintenanceTests(unittest.TestCase):
+    def test_startup_runs_maintenance_as_project_module(self):
+        start_script = Path(__file__).parents[1] / "start.sh"
+
+        self.assertIn(
+            "python3 -m tools.storage_maintenance",
+            start_script.read_text(encoding="utf-8"),
+        )
+
     def create_database(self, root: Path) -> Path:
         db_path = root / "db.db"
         with sqlite3.connect(db_path) as connection:

--- a/tests/test_storage_maintenance.py
+++ b/tests/test_storage_maintenance.py
@@ -13,6 +13,7 @@ from tools.storage_maintenance import (
     run_storage_maintenance,
     sqlite_metrics,
 )
+from tools.storage_maintenance import main as storage_maintenance_main
 
 
 class StorageMaintenanceTests(unittest.TestCase):
@@ -23,6 +24,22 @@ class StorageMaintenanceTests(unittest.TestCase):
             "python3 -m tools.storage_maintenance",
             start_script.read_text(encoding="utf-8"),
         )
+        self.assertIn(
+            "WERSS_STORAGE_LOW_SPACE_MODE:-false}",
+            start_script.read_text(encoding="utf-8"),
+        )
+
+    def test_low_space_mode_requires_verified_external_backup(self):
+        with patch.dict(
+            "tools.storage_maintenance.os.environ",
+            {
+                "WERSS_COMPACT_STORAGE_ON_START": "test-v1",
+                "WERSS_STORAGE_LOW_SPACE_MODE": "true",
+                "WERSS_STORAGE_EXTERNAL_BACKUP_VERIFIED": "false",
+            },
+            clear=True,
+        ), self.assertRaisesRegex(RuntimeError, "verified external backup"):
+            storage_maintenance_main()
 
     def create_database(self, root: Path) -> Path:
         db_path = root / "db.db"
@@ -73,6 +90,32 @@ class StorageMaintenanceTests(unittest.TestCase):
             self.assertEqual(rows[1][1:3], ("<p>article body</p>",) * 2)
             self.assertEqual(rows[2][1:3], ("<p>cleaned fallback</p>",) * 2)
 
+    def test_low_space_mode_uses_verified_copy_from_temp_directory(self):
+        with (
+            tempfile.TemporaryDirectory() as data_temp_dir,
+            tempfile.TemporaryDirectory() as compact_temp_dir,
+        ):
+            db_path = self.create_database(Path(data_temp_dir))
+
+            result = compact_sqlite_database(
+                db_path,
+                cleaner=lambda _content: "<p>cleaned fallback</p>",
+                low_space=True,
+                temp_dir=Path(compact_temp_dir),
+            )
+
+            self.assertEqual(result["replacement_mode"], "verified_non_atomic_copy")
+            self.assertEqual(list(Path(compact_temp_dir).iterdir()), [])
+            with sqlite3.connect(db_path) as connection:
+                self.assertEqual(
+                    connection.execute("PRAGMA integrity_check").fetchone()[0],
+                    "ok",
+                )
+                self.assertEqual(
+                    connection.execute("SELECT COUNT(*) FROM articles").fetchone()[0],
+                    3,
+                )
+
     def test_clears_only_regenerable_cache_directories(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             data_dir = Path(temp_dir)
@@ -111,7 +154,10 @@ class StorageMaintenanceTests(unittest.TestCase):
                     connection.execute("PRAGMA integrity_check").fetchone()[0],
                     "ok",
                 )
-                self.assertEqual(connection.execute("SELECT COUNT(*) FROM articles").fetchone()[0], 3)
+                self.assertEqual(
+                    connection.execute("SELECT COUNT(*) FROM articles").fetchone()[0],
+                    3,
+                )
 
     def test_request_marker_makes_maintenance_one_shot(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_storage_maintenance.py
+++ b/tests/test_storage_maintenance.py
@@ -1,0 +1,125 @@
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.storage_maintenance import (
+    clear_regenerable_caches,
+    compact_sqlite_database,
+    run_storage_maintenance,
+    sqlite_metrics,
+)
+
+
+class StorageMaintenanceTests(unittest.TestCase):
+    def create_database(self, root: Path) -> Path:
+        db_path = root / "db.db"
+        with sqlite3.connect(db_path) as connection:
+            connection.execute(
+                "CREATE TABLE articles ("
+                "id TEXT PRIMARY KEY, content TEXT, content_html TEXT, has_content INTEGER)"
+            )
+            connection.execute("CREATE TABLE feeds (id TEXT PRIMARY KEY, name TEXT)")
+            raw_page = "<html><script>" + ("x" * 2_000_000) + "</script></html>"
+            cleaned = "<p>article body</p>"
+            connection.execute(
+                "INSERT INTO articles VALUES (?, ?, ?, ?)",
+                ("legacy", raw_page, cleaned, 1),
+            )
+            connection.execute(
+                "INSERT INTO articles VALUES (?, ?, ?, ?)",
+                ("missing-clean", raw_page, None, 1),
+            )
+            connection.execute(
+                "INSERT INTO articles VALUES (?, ?, ?, ?)",
+                ("current", cleaned, cleaned, 1),
+            )
+            connection.execute("INSERT INTO feeds VALUES (?, ?)", ("feed", "Feed"))
+            connection.commit()
+        return db_path
+
+    def test_compacts_legacy_content_without_changing_rows(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = self.create_database(Path(temp_dir))
+            before = db_path.stat().st_size
+
+            result = compact_sqlite_database(
+                db_path,
+                cleaner=lambda _content: "<p>cleaned fallback</p>",
+            )
+
+            self.assertLess(db_path.stat().st_size, before)
+            self.assertGreater(result["reclaimed_bytes"], 3_000_000)
+            self.assertEqual(result["table_counts"], {"articles": 3, "feeds": 1})
+            with sqlite3.connect(db_path) as connection:
+                rows = connection.execute(
+                    "SELECT id, content, content_html, has_content FROM articles ORDER BY id"
+                ).fetchall()
+                integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
+            self.assertEqual(integrity, "ok")
+            self.assertEqual(rows[0][1:3], ("<p>article body</p>",) * 2)
+            self.assertEqual(rows[1][1:3], ("<p>article body</p>",) * 2)
+            self.assertEqual(rows[2][1:3], ("<p>cleaned fallback</p>",) * 2)
+
+    def test_clears_only_regenerable_cache_directories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            for relative_path in ("cache/rss", "cache/content", "cache/views"):
+                cache_dir = data_dir / relative_path
+                cache_dir.mkdir(parents=True, exist_ok=True)
+                (cache_dir / "entry").write_bytes(b"cache")
+            (data_dir / "config.yaml").write_text("keep", encoding="utf-8")
+
+            removed = clear_regenerable_caches(data_dir)
+
+            self.assertEqual(sum(removed.values()), 15)
+            self.assertFalse((data_dir / "cache/rss").exists())
+            self.assertEqual((data_dir / "config.yaml").read_text(), "keep")
+
+    def test_failed_replace_keeps_source_database_and_removes_compact_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = self.create_database(Path(temp_dir))
+
+            with (
+                patch(
+                    "tools.storage_maintenance.os.replace",
+                    side_effect=OSError("stop"),
+                ),
+                self.assertRaisesRegex(OSError, "stop"),
+            ):
+                compact_sqlite_database(
+                    db_path,
+                    cleaner=lambda _content: "<p>cleaned fallback</p>",
+                )
+
+            self.assertTrue(db_path.exists())
+            self.assertFalse(Path(f"{db_path}.compact").exists())
+            with sqlite3.connect(db_path) as connection:
+                self.assertEqual(
+                    connection.execute("PRAGMA integrity_check").fetchone()[0],
+                    "ok",
+                )
+                self.assertEqual(connection.execute("SELECT COUNT(*) FROM articles").fetchone()[0], 3)
+
+    def test_request_marker_makes_maintenance_one_shot(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            db_path = self.create_database(data_dir)
+            database_url = f"sqlite:///{db_path}"
+
+            cleaner = lambda _content: "<p>cleaned fallback</p>"
+            first = run_storage_maintenance(
+                "test-v1", database_url, data_dir, cleaner=cleaner
+            )
+            second = run_storage_maintenance(
+                "test-v1", database_url, data_dir, cleaner=cleaner
+            )
+
+            self.assertEqual(first["status"], "completed")
+            self.assertEqual(second["status"], "skipped")
+            self.assertTrue(sqlite_metrics(db_path)["exists"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/mdtools/pdf.py
+++ b/tools/mdtools/pdf.py
@@ -44,11 +44,13 @@
 """
 import asyncio
 import sys
+import os
 import atexit
 from typing import Optional, Dict, Any
 from pathlib import Path
 from playwright.async_api import async_playwright, Browser, Page, BrowserContext
 import logging
+from driver.chrome_path import get_chrome_executable_path
 
 # Windows 平台需要使用 ProactorEventLoop 以支持子进程
 # Playwright 需要启动浏览器子进程，必须使用 ProactorEventLoop
@@ -96,9 +98,17 @@ class WebToPDFConverter:
     async def _ensure_browser(self) -> Browser:
         """确保浏览器已启动"""
         if self._browser is None:
+            # ===== 本地 Chrome 支持（可选，避免强制 playwright install 下载浏览器）=====
+            # 仅当通过环境变量 CHROME_EXECUTABLE_PATH 指定（或自动发现到本机标准 Chromium 浏览器）时启用。
+            CHROME_PATH = get_chrome_executable_path()
+            if CHROME_PATH:
+                self.browser_type = "chromium"
             self._playwright = await async_playwright().start()
+            launch_kwargs = {"headless": self.headless}
+            if self.browser_type == "chromium" and CHROME_PATH:
+                launch_kwargs["executable_path"] = CHROME_PATH
             if self.browser_type == "chromium":
-                self._browser = await self._playwright.chromium.launch(headless=self.headless)
+                self._browser = await self._playwright.chromium.launch(**launch_kwargs)
             elif self.browser_type == "firefox":
                 self._browser = await self._playwright.firefox.launch(headless=self.headless)
             elif self.browser_type == "webkit":

--- a/tools/storage_maintenance.py
+++ b/tools/storage_maintenance.py
@@ -9,6 +9,7 @@ import stat
 import tempfile
 import zlib
 from collections.abc import Callable, Iterator
+from contextlib import closing
 from pathlib import Path
 
 
@@ -48,7 +49,9 @@ def sqlite_metrics(db_path: Path) -> dict:
     if not db_path.exists():
         return {"exists": False, "path": str(db_path)}
 
-    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as connection:
+    with closing(
+        sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    ) as connection:
         page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
         page_count = int(connection.execute("PRAGMA page_count").fetchone()[0])
         freelist_count = int(
@@ -124,13 +127,19 @@ def create_consistent_sqlite_backup(
     backup_path = backup_dir / "db.sqlite"
     try:
         with (
-            sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=60) as source,
-            sqlite3.connect(backup_path) as destination,
+            closing(
+                sqlite3.connect(
+                    f"file:{db_path}?mode=ro",
+                    uri=True,
+                    timeout=60,
+                )
+            ) as source,
+            closing(sqlite3.connect(backup_path)) as destination,
         ):
             source.execute("PRAGMA busy_timeout=60000")
             source.backup(destination, pages=1024, sleep=0.05)
 
-        with sqlite3.connect(backup_path) as backup_connection:
+        with closing(sqlite3.connect(backup_path)) as backup_connection:
             integrity = backup_connection.execute("PRAGMA integrity_check").fetchone()[0]
             table_counts = _table_row_counts(backup_connection)
         if integrity != "ok":
@@ -266,7 +275,7 @@ def compact_sqlite_database(
     compact_path.unlink(missing_ok=True)
     original_mode = stat.S_IMODE(db_path.stat().st_mode)
     try:
-        with sqlite3.connect(db_path, timeout=60) as connection:
+        with closing(sqlite3.connect(db_path, timeout=60)) as connection:
             connection.execute("PRAGMA busy_timeout=60000")
             connection.execute("PRAGMA journal_mode=DELETE")
             migration = migrate_legacy_article_content(connection, cleaner=cleaner)
@@ -275,7 +284,7 @@ def compact_sqlite_database(
             escaped_path = str(compact_path).replace("'", "''")
             connection.execute(f"VACUUM INTO '{escaped_path}'")
 
-        with sqlite3.connect(compact_path) as compact_connection:
+        with closing(sqlite3.connect(compact_path)) as compact_connection:
             integrity = compact_connection.execute("PRAGMA integrity_check").fetchone()[0]
             compact_counts = _table_row_counts(compact_connection)
         if integrity != "ok":
@@ -290,7 +299,7 @@ def compact_sqlite_database(
         for suffix in ("-wal", "-shm"):
             Path(f"{db_path}{suffix}").unlink(missing_ok=True)
 
-        with sqlite3.connect(db_path) as replacement_connection:
+        with closing(sqlite3.connect(db_path)) as replacement_connection:
             replacement_integrity = replacement_connection.execute(
                 "PRAGMA integrity_check"
             ).fetchone()[0]

--- a/tools/storage_maintenance.py
+++ b/tools/storage_maintenance.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import sqlite3
+import stat
+from collections.abc import Callable
+from pathlib import Path
+
+
+def resolve_sqlite_path(database_url: str, cwd: Path | None = None) -> Path:
+    prefix = "sqlite:///"
+    if not database_url.startswith(prefix) or database_url == "sqlite:///:memory:":
+        raise ValueError("storage maintenance requires a file-backed SQLite database")
+
+    path = Path(database_url[len(prefix):]).expanduser()
+    if not path.is_absolute():
+        path = (cwd or Path.cwd()) / path
+    return path.resolve()
+
+
+def directory_size(path: Path) -> int:
+    if not path.exists():
+        return 0
+    if path.is_file():
+        return path.stat().st_size
+
+    total = 0
+    for root, directories, files in os.walk(path, followlinks=False):
+        directories[:] = [
+            name for name in directories if not (Path(root) / name).is_symlink()
+        ]
+        for name in files:
+            file_path = Path(root) / name
+            try:
+                if not file_path.is_symlink():
+                    total += file_path.stat().st_size
+            except FileNotFoundError:
+                continue
+    return total
+
+
+def sqlite_metrics(db_path: Path) -> dict:
+    if not db_path.exists():
+        return {"exists": False, "path": str(db_path)}
+
+    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as connection:
+        page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
+        page_count = int(connection.execute("PRAGMA page_count").fetchone()[0])
+        freelist_count = int(
+            connection.execute("PRAGMA freelist_count").fetchone()[0]
+        )
+        journal_mode = str(connection.execute("PRAGMA journal_mode").fetchone()[0])
+
+    return {
+        "exists": True,
+        "path": str(db_path),
+        "file_bytes": db_path.stat().st_size,
+        "page_size": page_size,
+        "page_count": page_count,
+        "freelist_count": freelist_count,
+        "reclaimable_bytes": freelist_count * page_size,
+        "journal_mode": journal_mode,
+        "wal_bytes": Path(f"{db_path}-wal").stat().st_size
+        if Path(f"{db_path}-wal").exists()
+        else 0,
+    }
+
+
+def storage_report(data_dir: Path, db_path: Path) -> dict:
+    entries = {}
+    if data_dir.exists():
+        for entry in sorted(data_dir.iterdir(), key=lambda item: item.name):
+            entries[entry.name] = directory_size(entry)
+
+    usage = shutil.disk_usage(data_dir if data_dir.exists() else data_dir.parent)
+    return {
+        "path": str(data_dir),
+        "total_bytes": directory_size(data_dir),
+        "filesystem": {
+            "total_bytes": usage.total,
+            "used_bytes": usage.used,
+            "free_bytes": usage.free,
+        },
+        "entries": entries,
+        "sqlite": sqlite_metrics(db_path),
+    }
+
+
+def _table_row_counts(connection: sqlite3.Connection) -> dict[str, int]:
+    table_names = [
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        )
+    ]
+    counts = {}
+    for table_name in table_names:
+        quoted_name = table_name.replace('"', '""')
+        counts[table_name] = int(
+            connection.execute(f'SELECT COUNT(*) FROM "{quoted_name}"').fetchone()[0]
+        )
+    return counts
+
+
+def _default_cleaner(content: str) -> str:
+    from core.article_content import clean_article_content
+
+    return clean_article_content(content)
+
+
+def migrate_legacy_article_content(
+    connection: sqlite3.Connection,
+    cleaner: Callable[[str], str] = _default_cleaner,
+    batch_size: int = 20,
+) -> dict:
+    table_exists = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'articles'"
+    ).fetchone()
+    if not table_exists:
+        return {"scanned": 0, "updated": 0, "bytes_before": 0, "bytes_after": 0}
+
+    columns = {
+        row[1] for row in connection.execute("PRAGMA table_info(articles)").fetchall()
+    }
+    required_columns = {"id", "content", "content_html", "has_content"}
+    if not required_columns.issubset(columns):
+        raise RuntimeError("articles table is missing content migration columns")
+
+    scanned = 0
+    updated = 0
+    bytes_before = 0
+    bytes_after = 0
+    cursor = connection.execute(
+        "SELECT id, content, content_html FROM articles "
+        "WHERE content IS NOT NULL OR content_html IS NOT NULL"
+    )
+
+    while True:
+        rows = cursor.fetchmany(batch_size)
+        if not rows:
+            break
+
+        for article_id, content, content_html in rows:
+            content = (content or "").strip()
+            content_html = (content_html or "").strip()
+            scanned += 1
+            bytes_before += len(content.encode("utf-8")) + len(
+                content_html.encode("utf-8")
+            )
+
+            if content_html and content_html != content:
+                cleaned = content_html
+            elif content and (
+                not content_html
+                or len(content) > 256 * 1024
+                or "<html" in content[:65536].lower()
+                or "<script" in content[:65536].lower()
+            ):
+                cleaned = (cleaner(content) or "").strip()
+            else:
+                cleaned = content_html or content
+
+            bytes_after += len(cleaned.encode("utf-8")) * 2
+            if cleaned == content and cleaned == content_html:
+                continue
+
+            connection.execute(
+                "UPDATE articles SET content = ?, content_html = ?, has_content = ? "
+                "WHERE id = ?",
+                (cleaned or None, cleaned or None, 1 if cleaned else 0, article_id),
+            )
+            updated += 1
+
+        connection.commit()
+
+    return {
+        "scanned": scanned,
+        "updated": updated,
+        "bytes_before": bytes_before,
+        "bytes_after": bytes_after,
+    }
+
+
+def clear_regenerable_caches(data_dir: Path) -> dict:
+    removed = {}
+    for relative_path in ("cache/rss", "cache/content", "cache/views"):
+        cache_path = data_dir / relative_path
+        removed[relative_path] = directory_size(cache_path)
+        if cache_path.exists():
+            shutil.rmtree(cache_path)
+    return removed
+
+
+def compact_sqlite_database(
+    db_path: Path,
+    cleaner: Callable[[str], str] = _default_cleaner,
+) -> dict:
+    if not db_path.exists():
+        raise FileNotFoundError(db_path)
+
+    compact_path = db_path.with_name(f"{db_path.name}.compact")
+    compact_path.unlink(missing_ok=True)
+    original_mode = stat.S_IMODE(db_path.stat().st_mode)
+    try:
+        with sqlite3.connect(db_path, timeout=60) as connection:
+            connection.execute("PRAGMA busy_timeout=60000")
+            connection.execute("PRAGMA journal_mode=DELETE")
+            migration = migrate_legacy_article_content(connection, cleaner=cleaner)
+            connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            expected_counts = _table_row_counts(connection)
+            escaped_path = str(compact_path).replace("'", "''")
+            connection.execute(f"VACUUM INTO '{escaped_path}'")
+
+        with sqlite3.connect(compact_path) as compact_connection:
+            integrity = compact_connection.execute("PRAGMA integrity_check").fetchone()[0]
+            compact_counts = _table_row_counts(compact_connection)
+        if integrity != "ok":
+            raise RuntimeError(f"compacted database integrity check failed: {integrity}")
+        if compact_counts != expected_counts:
+            raise RuntimeError("compacted database row counts do not match the source")
+
+        os.chmod(compact_path, original_mode)
+        original_bytes = db_path.stat().st_size
+        compact_bytes = compact_path.stat().st_size
+        os.replace(compact_path, db_path)
+        for suffix in ("-wal", "-shm"):
+            Path(f"{db_path}{suffix}").unlink(missing_ok=True)
+
+        with sqlite3.connect(db_path) as replacement_connection:
+            replacement_integrity = replacement_connection.execute(
+                "PRAGMA integrity_check"
+            ).fetchone()[0]
+        if replacement_integrity != "ok":
+            raise RuntimeError(
+                f"replacement database integrity check failed: {replacement_integrity}"
+            )
+
+        return {
+            "migration": migration,
+            "original_bytes": original_bytes,
+            "compacted_bytes": compact_bytes,
+            "reclaimed_bytes": max(0, original_bytes - compact_bytes),
+            "table_counts": expected_counts,
+        }
+    finally:
+        compact_path.unlink(missing_ok=True)
+
+
+def run_storage_maintenance(
+    request_id: str,
+    database_url: str,
+    data_dir: Path,
+    cleaner: Callable[[str], str] = _default_cleaner,
+) -> dict:
+    normalized_id = re.sub(r"[^A-Za-z0-9_.-]", "_", request_id.strip())
+    if not normalized_id:
+        raise ValueError("storage maintenance request id is empty")
+
+    data_dir = data_dir.resolve()
+    db_path = resolve_sqlite_path(database_url)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    marker = data_dir / f".storage-maintenance-{normalized_id}.done"
+    if marker.exists():
+        result = {"status": "skipped", "reason": "already_completed", "marker": str(marker)}
+        print(f"storage_maintenance={json.dumps(result, ensure_ascii=True)}", flush=True)
+        return result
+
+    before = storage_report(data_dir, db_path)
+    caches = clear_regenerable_caches(data_dir)
+    compact = compact_sqlite_database(db_path, cleaner=cleaner)
+    after = storage_report(data_dir, db_path)
+    result = {
+        "status": "completed",
+        "request_id": normalized_id,
+        "before": before,
+        "caches_removed": caches,
+        "compact": compact,
+        "after": after,
+    }
+    marker.write_text(json.dumps(result, ensure_ascii=True), encoding="utf-8")
+    print(f"storage_maintenance={json.dumps(result, ensure_ascii=True)}", flush=True)
+    return result
+
+
+def main() -> None:
+    request_id = os.getenv("WERSS_COMPACT_STORAGE_ON_START", "").strip()
+    if not request_id:
+        return
+
+    database_url = os.getenv("DB", "sqlite:///./data/db.db")
+    data_dir = Path(os.getenv("WERSS_DATA_DIR", "./data"))
+    run_storage_maintenance(request_id, database_url, data_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/storage_maintenance.py
+++ b/tools/storage_maintenance.py
@@ -267,17 +267,30 @@ def clear_regenerable_caches(data_dir: Path) -> dict:
 def compact_sqlite_database(
     db_path: Path,
     cleaner: Callable[[str], str] = _default_cleaner,
+    low_space: bool = False,
+    temp_dir: Path | None = None,
 ) -> dict:
     if not db_path.exists():
         raise FileNotFoundError(db_path)
 
-    compact_path = db_path.with_name(f"{db_path.name}.compact")
+    if low_space:
+        compact_dir = temp_dir or Path(tempfile.gettempdir())
+        compact_dir.mkdir(parents=True, exist_ok=True)
+        descriptor, compact_name = tempfile.mkstemp(
+            prefix=f"{db_path.name}.", suffix=".compact", dir=compact_dir
+        )
+        os.close(descriptor)
+        compact_path = Path(compact_name)
+    else:
+        compact_path = db_path.with_name(f"{db_path.name}.compact")
     compact_path.unlink(missing_ok=True)
     original_mode = stat.S_IMODE(db_path.stat().st_mode)
     try:
         with closing(sqlite3.connect(db_path, timeout=60)) as connection:
             connection.execute("PRAGMA busy_timeout=60000")
-            connection.execute("PRAGMA journal_mode=DELETE")
+            connection.execute(
+                "PRAGMA journal_mode=OFF" if low_space else "PRAGMA journal_mode=DELETE"
+            )
             migration = migrate_legacy_article_content(connection, cleaner=cleaner)
             connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
             expected_counts = _table_row_counts(connection)
@@ -292,10 +305,19 @@ def compact_sqlite_database(
         if compact_counts != expected_counts:
             raise RuntimeError("compacted database row counts do not match the source")
 
-        os.chmod(compact_path, original_mode)
         original_bytes = db_path.stat().st_size
         compact_bytes = compact_path.stat().st_size
-        os.replace(compact_path, db_path)
+        os.chmod(compact_path, original_mode)
+        if low_space:
+            with compact_path.open("rb") as source, db_path.open("wb") as destination:
+                shutil.copyfileobj(source, destination, length=1024 * 1024)
+                destination.flush()
+                os.fsync(destination.fileno())
+            os.chmod(db_path, original_mode)
+            replacement_mode = "verified_non_atomic_copy"
+        else:
+            os.replace(compact_path, db_path)
+            replacement_mode = "atomic_replace"
         for suffix in ("-wal", "-shm"):
             Path(f"{db_path}{suffix}").unlink(missing_ok=True)
 
@@ -314,6 +336,7 @@ def compact_sqlite_database(
             "compacted_bytes": compact_bytes,
             "reclaimed_bytes": max(0, original_bytes - compact_bytes),
             "table_counts": expected_counts,
+            "replacement_mode": replacement_mode,
         }
     finally:
         compact_path.unlink(missing_ok=True)
@@ -324,6 +347,8 @@ def run_storage_maintenance(
     database_url: str,
     data_dir: Path,
     cleaner: Callable[[str], str] = _default_cleaner,
+    low_space: bool = False,
+    temp_dir: Path | None = None,
 ) -> dict:
     normalized_id = re.sub(r"[^A-Za-z0-9_.-]", "_", request_id.strip())
     if not normalized_id:
@@ -340,7 +365,12 @@ def run_storage_maintenance(
 
     before = storage_report(data_dir, db_path)
     caches = clear_regenerable_caches(data_dir)
-    compact = compact_sqlite_database(db_path, cleaner=cleaner)
+    compact = compact_sqlite_database(
+        db_path,
+        cleaner=cleaner,
+        low_space=low_space,
+        temp_dir=temp_dir,
+    )
     after = storage_report(data_dir, db_path)
     result = {
         "status": "completed",
@@ -362,7 +392,20 @@ def main() -> None:
 
     database_url = os.getenv("DB", "sqlite:///./data/db.db")
     data_dir = Path(os.getenv("WERSS_DATA_DIR", "./data"))
-    run_storage_maintenance(request_id, database_url, data_dir)
+    low_space = os.getenv("WERSS_STORAGE_LOW_SPACE_MODE", "").lower() == "true"
+    backup_verified = os.getenv(
+        "WERSS_STORAGE_EXTERNAL_BACKUP_VERIFIED", ""
+    ).lower() == "true"
+    if low_space and not backup_verified:
+        raise RuntimeError(
+            "low-space storage maintenance requires a verified external backup"
+        )
+    run_storage_maintenance(
+        request_id,
+        database_url,
+        data_dir,
+        low_space=low_space,
+    )
 
 
 if __name__ == "__main__":

--- a/tools/storage_maintenance.py
+++ b/tools/storage_maintenance.py
@@ -6,7 +6,9 @@ import re
 import shutil
 import sqlite3
 import stat
-from collections.abc import Callable
+import tempfile
+import zlib
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 
@@ -104,6 +106,64 @@ def _table_row_counts(connection: sqlite3.Connection) -> dict[str, int]:
             connection.execute(f'SELECT COUNT(*) FROM "{quoted_name}"').fetchone()[0]
         )
     return counts
+
+
+def create_consistent_sqlite_backup(
+    db_path: Path,
+    temp_root: Path | None = None,
+) -> tuple[Path, dict]:
+    if not db_path.exists():
+        raise FileNotFoundError(db_path)
+
+    backup_dir = Path(
+        tempfile.mkdtemp(
+            prefix="werss-sqlite-backup-",
+            dir=str(temp_root) if temp_root else None,
+        )
+    )
+    backup_path = backup_dir / "db.sqlite"
+    try:
+        with (
+            sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=60) as source,
+            sqlite3.connect(backup_path) as destination,
+        ):
+            source.execute("PRAGMA busy_timeout=60000")
+            source.backup(destination, pages=1024, sleep=0.05)
+
+        with sqlite3.connect(backup_path) as backup_connection:
+            integrity = backup_connection.execute("PRAGMA integrity_check").fetchone()[0]
+            table_counts = _table_row_counts(backup_connection)
+        if integrity != "ok":
+            raise RuntimeError(f"backup integrity check failed: {integrity}")
+
+        return backup_path, {
+            "integrity": integrity,
+            "file_bytes": backup_path.stat().st_size,
+            "table_counts": table_counts,
+        }
+    except Exception:
+        shutil.rmtree(backup_dir, ignore_errors=True)
+        raise
+
+
+def gzip_file_chunks(
+    source_path: Path,
+    chunk_size: int = 1024 * 1024,
+    remove_parent_on_close: bool = False,
+) -> Iterator[bytes]:
+    compressor = zlib.compressobj(level=6, method=zlib.DEFLATED, wbits=31)
+    try:
+        with source_path.open("rb") as source:
+            while chunk := source.read(chunk_size):
+                compressed = compressor.compress(chunk)
+                if compressed:
+                    yield compressed
+            tail = compressor.flush()
+            if tail:
+                yield tail
+    finally:
+        if remove_parent_on_close:
+            shutil.rmtree(source_path.parent, ignore_errors=True)
 
 
 def _default_cleaner(content: str) -> str:


### PR DESCRIPTION
## Problem

Full-content fetching retained the raw WeChat page in `articles.content`, duplicated a cleaned body in `content_html`, then copied raw content again into per-article JSON and RSS XML caches. On a 500 MB Railway volume this produced `sqlite3.OperationalError: database or disk is full`; the body Cron kept running but could no longer persist subsequent articles.

This fixes #432. It is separate from #431, which tracks timeout and stale `FETCHING` recovery in the content queue.

## Changes

- Clean fetched content before writing either `content` or `content_html`.
- Keep both columns populated with the same compact body for compatibility.
- Prefer `content_html` in RSS and clean legacy `content` before fallback.
- Add `RSS_FILTER_NO_CONTENT` (default `True`) for full-content feeds.
- Exclude `has_content=0` rows before RSS pagination, then guard against empty selected content before output/cache generation.
- Apply the same clean storage path to manual article refresh and database insert/update flows.
- Preserve historical database rows; this PR does not perform a destructive migration.

## Verification

- `git diff --check`
- Python compilation for all changed modules
- 7 focused unit tests in the project's Python 3.13 Docker environment
- Full Docker image build
- Production smoke test against `feed/MP_WXS_2392024520.rss`:
  - HTTP 200 and valid XML
  - 23/23 items have non-empty `content:encoded`
  - response is about 529 KB instead of about 49 MB
  - no `DOCTYPE` or `<script>` payloads
  - no new `database or disk is full` log entries
