### PR TITLE
feat: automatically catch up missed articles

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -170,7 +170,7 @@ http://localhost:3000
 | `WEB_NAME` | `WeRSS微信公众号订阅助手` | 前端显示名称 |
 | `WERSS_AUTH_WEB` | `False` | 通过web方式授权 |
 | `BROWSER_TYPE` | `firefox` | 浏览器类型默认firefox |
-| `SEND_CODE` | `True` | 是否发送授权二维码通知 |
+| `SEND_CODE` | `False` | 过期通知中是否附带授权二维码（默认仅发送文字通知） |
 | `CODE_TITLE` | `WeRSS授权二维码` | 二维码通知标题 |
 | `ENABLE_JOB` | `True` | 是否启用定时任务 |
 | `AUTO_RELOAD` | `False` | 代码修改自动重启服务 |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -220,7 +220,7 @@ The following are the environment variable configurations supported in `config.y
 | `APP_NAME` | `we-mp-rss` | Application name |
 | `SERVER_NAME` | `we-mp-rss` | Server name |
 | `WEB_NAME` | `WeRSS微信公众号订阅助手` | Frontend display name |
-| `SEND_CODE` | `True` | Whether to send authorization QR code notifications |
+| `SEND_CODE` | `False` | Whether to send authorization QR code in expired notification (text-only notification by default) |
 | `CODE_TITLE` | `WeRSS授权二维码` | QR code notification title |
 | `ENABLE_JOB` | `True` | Whether to enable scheduled tasks |
 | `AUTO_RELOAD` | `False` | Auto-restart service on code changes |

--- a/apis/article.py
+++ b/apis/article.py
@@ -167,6 +167,8 @@ async def clean_orphan_articles(
                 message="清理无效文章失败"
             )
         )
+    finally:
+        session.close()
 
 
 @router.delete("/clean-old", summary="清理指定天数前的旧文章")

--- a/apis/message_task.py
+++ b/apis/message_task.py
@@ -199,8 +199,12 @@ async def run_message_task(
             import json
             for task in tasks:
                 try:
-                    ids=json.loads(task.mps_id)
-                    count+=len(ids)
+                    # mps_id 可能为空（UI 提示"留空则对所有公众号生效"），
+                    # 通过 get_feeds() 拿实际 feed 数，与 jobs/mps.py 一致
+                    from jobs.mps import get_feeds
+                    feeds = get_feeds(task)
+                    ids = [{"id": f.id, "name": f.mp_name} for f in feeds]
+                    count += len(ids)
                     mps['count']=count
                     mps['list'].append(ids)
                 except Exception as e:

--- a/apis/message_task.py
+++ b/apis/message_task.py
@@ -1,3 +1,4 @@
+import asyncio
 from pydantic import BaseModel
 
 # 标准导入分组和顺序
@@ -148,7 +149,7 @@ async def test_message_task(
             articles=mock_articles  # type: ignore
         )
         
-        result = web_hook(test_hook, is_test=True)
+        result = await asyncio.to_thread(web_hook, test_hook, is_test=True)
         
         return success_response(
             data={

--- a/config-node.yaml
+++ b/config-node.yaml
@@ -4,8 +4,8 @@ server:
    name: ${SERVER_NAME:-we-mp-rss}
    #前端显示名称
    web_name: ${WEB_NAME:-WeRSS微信公众号订阅助手}
-   #过期是否发送授权二维通知 默认True
-   send_code: ${SEND_CODE:-True}
+   #过期是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${SEND_CODE:-False}
    #二维通知标题
    code_title: ${CODE_TITLE:-WeRSS}
    #启动JOB定时任务，默认为True
@@ -16,8 +16,8 @@ server:
    threads: ${THREADS:-1}
    #通过web方式授权二维码 默认False 
    auth_web: ${WERSS_AUTH_WEB:-False}
-   #是否发送授权二维通知 默认True
-   send_code: ${WERSS_SEND_CODE:-True}
+   #是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${WERSS_SEND_CODE:-False}
 
 
 #数据库连接 例如db:  mysql+pymysql://<username>:<password>@<host>/we-rss?charset=utf8mb4

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,8 +4,8 @@ server:
    name: ${SERVER_NAME:-we-mp-rss}
    #前端显示名称
    web_name: ${WEB_NAME:-WeRSS微信公众号订阅助手}
-   #过期是否发送授权二维通知 默认True
-   send_code: ${SEND_CODE:-True}
+   #过期是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${SEND_CODE:-False}
    #二维通知标题
    code_title: ${CODE_TITLE:-WeRSS}
    #启动JOB定时任务，默认为True
@@ -16,8 +16,8 @@ server:
    threads: ${THREADS:-1}
    #通过web方式授权二维码 默认False 
    auth_web: ${WERSS_AUTH_WEB:-False}
-   #是否发送授权二维通知 默认True
-   send_code: ${WERSS_SEND_CODE:-True}
+   #是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${WERSS_SEND_CODE:-False}
    #是否启用自动刷新文章统计 默认False
    article_stats_refresh_enabled: ${ARTICLE_STATS_REFRESH_ENABLED:-False}
    # 文章统计刷新间隔 默认300秒

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -126,6 +126,8 @@ gather:
   content: ${GATHER.CONTENT:-False}
   #采集模式，web模式（可采集到发布链接)，api模式（可采集临时链接），app模式（采集最新消息）
   model: ${GATHER.MODEL:-web}
+  #定时抓取自动补历史文章的最大页数，遇到已存在文章会提前停止；建议10，允许1-20
+  catch_up_max_pages: ${GATHER.CATCH_UP_MAX_PAGES:-10}
   #是否自动检查未采集文章内容，默认False
   content_auto_check: ${GATHER.CONTENT_AUTO_CHECK:-True}
   #自动检查未采集文章内容的时间间隔 单位秒默认59分钟 允许值 1-59分钟之间 默认59分钟

--- a/core/db.py
+++ b/core/db.py
@@ -123,6 +123,7 @@ class Db:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
     def delete_article(self,article_data:dict)->bool:
+        session = None
         try:
             art = Article(**article_data)
             if art.id: # type: ignore
@@ -136,9 +137,13 @@ class Db:
         except Exception as e:
             print_error(f"delete article:{str(e)}")
             pass      
+        finally:
+            if session is not None:
+                session.close()
         return False
      
     def add_article(self, article_data: dict,check_exist=True) -> bool:
+        session = None
         try:
             session=self.get_session()
             from datetime import datetime
@@ -194,48 +199,70 @@ class Db:
             session.add(art)
             print_info(f"Added article: {art.id}")
             sta=session.commit()
+            return True
         except Exception as e:
-            session.rollback()  # 回滚事务，确保session状态正常
+            if session:
+                session.rollback()  # 回滚事务，确保session状态正常
             if "UNIQUE" in str(e) or "Duplicate entry" in str(e):
                 print_warning(f"Article already exists: {art.id}")
             else:
                 print_error(f"Failed to add article: {e}")
             return False
-        return True    
-        
+        finally:
+            if session is not None:
+                session.close()
     def get_articles(self, id:str=None, limit:int=30, offset:int=0) -> List[Article]: # type: ignore
+        session = None
         try:
-            data = self.get_session().query(Article).limit(limit).offset(offset)
+            session = self.get_session()
+            data = session.query(Article).limit(limit).offset(offset)
             return data
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore   
+        finally:
+            if session is not None:
+                session.close()
              
     def get_all_mps(self) -> List[Feed]:
         """Get all Feed records"""
+        session = None
         try:
-            return self.get_session().query(Feed).all()
+            session = self.get_session()
+            return session.query(Feed).filter(Feed.status == 1).all()
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore
+        finally:
+            if session is not None:
+                session.close()
             
     def get_mps_list(self, mp_ids:str) -> List[Feed]:
+        session = None
         try:
             ids=mp_ids.split(',')
-            data =  self.get_session().query(Feed).filter(Feed.id.in_(ids)).all()
+            session = self.get_session()
+            data = session.query(Feed).filter(Feed.id.in_(ids)).all()
             return data
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore
+        finally:
+            if session is not None:
+                session.close()
     def get_mps(self, mp_id:str) -> Optional[Feed]:
+        session = None
         try:
             ids=mp_id.split(',')
-            data =  self.get_session().query(Feed).filter_by(id= mp_id).first()
+            session = self.get_session()
+            data = session.query(Feed).filter_by(id= mp_id).first()
             return data
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore
-
+        finally:
+            if session is not None:
+                session.close()
     def get_faker_id(self, mp_id:str):
         data = self.get_mps(mp_id)
         return data.faker_id # type: ignore

--- a/core/db.py
+++ b/core/db.py
@@ -69,6 +69,9 @@ class Db:
                 @event.listens_for(self.engine, "connect")
                 def set_sqlite_text_factory(dbapi_conn, connection_record):
                     # 将无效 UTF-8 字符替换为 �
+                    dbapi_conn.execute("PRAGMA journal_mode=WAL")
+                    dbapi_conn.execute("PRAGMA busy_timeout=10000")
+                    dbapi_conn.execute("PRAGMA synchronous=NORMAL")
                     dbapi_conn.text_factory = lambda x: x.decode('utf-8', errors='replace')
             
             self.session_factory=self.get_session_factory()
@@ -229,7 +232,7 @@ class Db:
         session = None
         try:
             session = self.get_session()
-            return session.query(Feed).filter(Feed.status == 1).all()
+            return session.query(Feed).filter(Feed.status == 1, Feed.faker_id != "MP_WXS_FEATURED_ARTICLES").all()
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore

--- a/core/gather_pagination.py
+++ b/core/gather_pagination.py
@@ -1,0 +1,17 @@
+DEFAULT_CATCH_UP_MAX_PAGES = 10
+HARD_CATCH_UP_MAX_PAGES = 20
+
+
+def normalize_catch_up_max_pages(value) -> int:
+    try:
+        pages = int(value)
+    except (TypeError, ValueError):
+        pages = DEFAULT_CATCH_UP_MAX_PAGES
+
+    return min(max(pages, 1), HARD_CATCH_UP_MAX_PAGES)
+
+
+def should_stop_after_page(callback_results, stop_on_existing: bool) -> bool:
+    if not stop_on_existing:
+        return False
+    return any(result is False for result in callback_results)

--- a/core/notice/custom.py
+++ b/core/notice/custom.py
@@ -20,7 +20,8 @@ def send_custom_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/dingtalk.py
+++ b/core/notice/dingtalk.py
@@ -27,7 +27,8 @@ def send_dingtalk_message(webhook_url, title, text, is_at_all=False, at_mobiles=
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/feishu.py
+++ b/core/notice/feishu.py
@@ -40,7 +40,8 @@ def send_feishu_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/wechat.py
+++ b/core/notice/wechat.py
@@ -24,7 +24,8 @@ def send_wechat_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/queue/queue.py
+++ b/core/queue/queue.py
@@ -368,9 +368,16 @@ class TaskQueueManager:
                 max_retries=max_retries
             ))
             
-            # 保存到 Redis
-            self._save_pending_to_redis()
-            self._save_status_to_redis()
+            # 优化：只追加新任务到 Redis，而不是全量重写
+            redis_client = _get_redis()
+            if redis_client:
+                try:
+                    new_item = self._pending_items[-1].to_dict()
+                    redis_client.rpush(self._redis_keys['pending'], json.dumps(new_item, ensure_ascii=False))
+                    # 只更新计数，不保存完整状态
+                    redis_client.hincrby(self._redis_keys['status'], 'pending_count', 1)
+                except Exception as e:
+                    print_error(f"追加任务到 Redis 失败: {e}")
             
             # 标记需要广播，但不在这里执行（避免在锁内进行异步操作）
             broadcast_needed = True

--- a/core/queue/queue.py
+++ b/core/queue/queue.py
@@ -6,6 +6,7 @@ import json
 from typing import Callable, Any, Optional
 from datetime import datetime
 from dataclasses import dataclass, field, asdict
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from core.print import print_error, print_info, print_warning, print_success
 
 # Redis 键前缀 - 主队列（文章列表采集）
@@ -457,7 +458,15 @@ class TaskQueueManager:
                         try:
                             # 记录任务开始时间
                             start_time = time.time()
-                            task(*args, **kwargs)
+                            task_executor = ThreadPoolExecutor(max_workers=1)
+                            try:
+                                future = task_executor.submit(task, *args, **kwargs)
+                                future.result(timeout=600)
+                            except FutureTimeoutError:
+                                print_error("Task [{}] execution timeout (10 min)".format(task_name))
+                                raise Exception("Task timed out after 600s")
+                            finally:
+                                task_executor.shutdown(wait=False)
                             # 记录任务执行时间
                             duration = time.time() - start_time
                             

--- a/core/test_gather_pagination.py
+++ b/core/test_gather_pagination.py
@@ -1,0 +1,85 @@
+import ast
+import unittest
+from pathlib import Path
+
+from core.gather_pagination import (
+    DEFAULT_CATCH_UP_MAX_PAGES,
+    HARD_CATCH_UP_MAX_PAGES,
+    normalize_catch_up_max_pages,
+    should_stop_after_page,
+)
+
+
+class PaginationTest(unittest.TestCase):
+    def test_normalize_uses_default_for_invalid_value(self):
+        self.assertEqual(
+            normalize_catch_up_max_pages("invalid"),
+            DEFAULT_CATCH_UP_MAX_PAGES,
+        )
+
+    def test_normalize_clamps_page_range(self):
+        self.assertEqual(normalize_catch_up_max_pages(0), 1)
+        self.assertEqual(
+            normalize_catch_up_max_pages(999),
+            HARD_CATCH_UP_MAX_PAGES,
+        )
+
+    def test_stop_after_page_when_existing_article_is_seen(self):
+        self.assertTrue(should_stop_after_page([True, False, True], True))
+
+    def test_continue_when_page_only_contains_new_articles(self):
+        self.assertFalse(should_stop_after_page([True, True], True))
+
+    def test_manual_pagination_ignores_existing_articles(self):
+        self.assertFalse(should_stop_after_page([False], False))
+
+    def test_all_gather_models_wire_automatic_stop(self):
+        root = Path(__file__).resolve().parent
+        for model_name in ("web", "app", "api"):
+            source = (root / "wx/model" / f"{model_name}.py").read_text(
+                encoding="utf-8"
+            )
+            tree = ast.parse(source)
+            get_articles = next(
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.FunctionDef)
+                and node.name == "get_Articles"
+            )
+            argument_names = [argument.arg for argument in get_articles.args.args]
+            called_functions = {
+                ast.unparse(node.func)
+                for node in ast.walk(get_articles)
+                if isinstance(node, ast.Call)
+            }
+
+            self.assertIn("StopOnExisting", argument_names)
+            self.assertIn("should_stop_after_page", called_functions)
+
+    def test_scheduler_enables_catch_up_mode(self):
+        root = Path(__file__).resolve().parent
+        source = (root.parent / "jobs/mps.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        get_article_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get_Articles"
+        ]
+
+        self.assertTrue(
+            any(
+                any(
+                    keyword.arg == "StopOnExisting"
+                    and isinstance(keyword.value, ast.Constant)
+                    and keyword.value.value is True
+                    for keyword in call.keywords
+                )
+                for call in get_article_calls
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/wx/base.py
+++ b/core/wx/base.py
@@ -320,11 +320,10 @@ class WxGather:
         if code=="Invalid Session":
             # from core.queue import TaskQueue
             # TaskQueue.clear_queue()  # 已注释：避免微信认证失效时清空队列
-            if cfg.get("server.send_code")=="True":
-                from jobs.failauth import send_wx_code
-                import threading
-                setStatus(False)
-                threading.Thread(target=send_wx_code,args=(f"公众号平台登录失效,请重新登录",)).start()
+            from jobs.failauth import send_wx_code
+            import threading
+            setStatus(False)
+            threading.Thread(target=send_wx_code,args=(f"公众号平台登录失效,请重新登录",)).start()
             # send_wx_code(f"公众号平台登录失效,请重新登录")
             raise Exception(error)
         # raise Exception(error)

--- a/core/wx/base.py
+++ b/core/wx/base.py
@@ -238,10 +238,13 @@ class WxGather:
                 }
                 if 'digest' in data:
                     art['description']=data['digest']
-                if CallBack(art):
+                callback_result = CallBack(art)
+                if callback_result:
                     art["ext"]=Ext_Data
                     # art.pop("content")
                     self.articles.append(art)
+                return callback_result
+        return None
 
     #通过公众号码平台接口查询公众号
     def search_Biz(self,kw:str="",limit=10,offset=0):

--- a/core/wx/model/api.py
+++ b/core/wx/model/api.py
@@ -21,8 +21,7 @@ class MpsApi(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page=0,MaxPage:int=1,interval=10,Gather_Content=True,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-             Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"API获取模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsg"

--- a/core/wx/model/api.py
+++ b/core/wx/model/api.py
@@ -6,6 +6,7 @@ import yaml
 import re
 from bs4 import BeautifulSoup
 from core.wx.base import WxGather
+from core.gather_pagination import should_stop_after_page
 from core.print import print_error
 from core.log import logger
 # 继承 BaseGather 类
@@ -19,7 +20,7 @@ class MpsApi(WxGather):
                 logger.error(e)
         return ""
     # 重写 get_Articles 方法
-    def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page=0,MaxPage:int=1,interval=10,Gather_Content=True,Item_Over_CallBack=None,Over_CallBack=None):
+    def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page=0,MaxPage:int=1,interval=10,Gather_Content=True,Item_Over_CallBack=None,Over_CallBack=None,StopOnExisting:bool=False):
         super().Start(mp_id=Mps_id)
         Gather_Content = self.Gather_Content
         print(f"API获取模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
@@ -51,6 +52,7 @@ class MpsApi(WxGather):
             # 随机暂停几秒，避免过快的请求导致过快的被查到
             time.sleep(random.randint(0,interval))
             try:
+                callback_results = []
                 headers = self.fix_header(url)
                 resp = session.get(url, headers=headers, params = params, verify=False)
                 
@@ -86,10 +88,13 @@ class MpsApi(WxGather):
                         item["id"] = item["aid"]
                         item["mp_id"] = Mps_id
                         if CallBack is not None:
-                            super().FillBack(CallBack=CallBack,data=item,Ext_Data={"mp_title":Mps_title,"mp_id":Mps_id})
+                            callback_results.append(super().FillBack(CallBack=CallBack,data=item,Ext_Data={"mp_title":Mps_title,"mp_id":Mps_id}))
                     print(f"第{i+1}页爬取成功\n")
                 # 翻页
                 i += 1
+                if should_stop_after_page(callback_results, StopOnExisting):
+                    print("检测到已存在文章，停止自动翻页")
+                    break
             except requests.exceptions.Timeout:
                 print("Request timed out")
                 break

--- a/core/wx/model/app.py
+++ b/core/wx/model/app.py
@@ -26,8 +26,7 @@ class MpsAppMsg(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-            Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"APP浏览器模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsgpublish"

--- a/core/wx/model/app.py
+++ b/core/wx/model/app.py
@@ -6,6 +6,7 @@ import yaml
 import re
 from bs4 import BeautifulSoup
 from core.wx.base import WxGather
+from core.gather_pagination import should_stop_after_page
 from core.print import print_error
 from core.log import logger
 # 继承 BaseGather 类
@@ -24,7 +25,7 @@ class MpsAppMsg(WxGather):
             logger.error(e)
         return ""
     # 重写 get_Articles 方法
-    def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None):
+    def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None,StopOnExisting:bool=False):
         super().Start(mp_id=Mps_id)
         Gather_Content = self.Gather_Content
         print(f"APP浏览器模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
@@ -55,6 +56,7 @@ class MpsAppMsg(WxGather):
             # 随机暂停几秒，避免过快的请求导致过快的被查到
             time.sleep(random.randint(0,interval))
             try:
+                callback_results = []
                 headers = self.fix_header(url)
                 resp = session.get(url, headers=headers, params = params, verify=False)
                 
@@ -96,10 +98,13 @@ class MpsAppMsg(WxGather):
                                     item["id"] = item["aid"]
                                     item["mp_id"] = Mps_id
                                     if CallBack is not None:
-                                        super().FillBack(CallBack=CallBack,data=item,Ext_Data={"mp_title":Mps_title,"mp_id":Mps_id})
+                                        callback_results.append(super().FillBack(CallBack=CallBack,data=item,Ext_Data={"mp_title":Mps_title,"mp_id":Mps_id}))
                     print(f"第{i+1}页爬取成功\n")
                 # 翻页
                 i += 1
+                if should_stop_after_page(callback_results, StopOnExisting):
+                    print("检测到已存在文章，停止自动翻页")
+                    break
             except requests.exceptions.Timeout:
                 print("Request timed out")
                 break

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -57,7 +57,7 @@ class MpsWeb(WxGather):
             time.sleep(random.randint(0,interval))
             try:
                 headers = self.fix_header(url)
-                resp = session.get(url, headers=headers, params = params, verify=False)
+                resp = session.get(url, headers=headers, params = params, verify=False, timeout=(10, 30))
                 
                 msg = resp.json()
                 self._cookies =resp.cookies

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -26,8 +26,7 @@ class MpsWeb(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str='',Mps_id:str='',Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-            Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"Web浏览器模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsgpublish"

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -69,6 +69,15 @@ class MpsWeb(WxGather):
                 if msg['base_resp']['ret'] == 200003:
                     super().Error("Invalid Session, stop at {}".format(str(begin)),code="Invalid Session")
                     break
+                # 处理200002错误：参数无效
+                if msg['base_resp']['ret'] == 200002:
+                    super().Error("Invalid arguments, stop at {}".format(str(begin)), code="Invalid Arguments")
+                    # 设置feed状态为0并继续下一个任务
+                    self._set_feed_status(Mps_id, 0)
+                    # 不break，而是return，这样可以继续下一个任务
+                    super().Item_Over(item={"mps_id":Mps_id,"mps_title":Mps_title},CallBack=Item_Over_CallBack)
+                    super().Over(CallBack=Over_CallBack)
+                    return
                 if msg['base_resp']['ret'] != 0:
                     super().Error("错误原因:{}:代码:{}".format(msg['base_resp']['err_msg'],msg['base_resp']['ret']),code=msg['base_resp']['err_msg'])
                     break    
@@ -112,3 +121,19 @@ class MpsWeb(WxGather):
                 super().Item_Over(item={"mps_id":Mps_id,"mps_title":Mps_title},CallBack=Item_Over_CallBack)
         super().Over(CallBack=Over_CallBack)
         pass
+    # 新增辅助方法用于设置feed状态
+    def _set_feed_status(self, feed_id: str, status: int):
+        """设置feed状态"""
+        try:
+            from core.db import DB
+            from core.models import Feed
+            session = DB.get_session()
+            feed = session.query(Feed).filter(Feed.id == feed_id).first()
+            if feed:
+                feed.status = status
+                session.commit()
+                print(f"已将feed {feed_id} 的状态设置为 {status}")
+            else:
+                print(f"未找到feed {feed_id}")
+        except Exception as e:
+            logger.error(f"设置feed状态失败: {e}")

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -6,6 +6,7 @@ import yaml
 import re
 from bs4 import BeautifulSoup
 from core.wx.base import WxGather
+from core.gather_pagination import should_stop_after_page
 from core.print import print_error
 from core.log import logger
 # 继承 BaseGather 类
@@ -24,7 +25,7 @@ class MpsWeb(WxGather):
             logger.error(e)
         return ""
     # 重写 get_Articles 方法
-    def get_Articles(self, faker_id:str='',Mps_id:str='',Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None):
+    def get_Articles(self, faker_id:str='',Mps_id:str='',Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None,StopOnExisting:bool=False):
         super().Start(mp_id=Mps_id)
         Gather_Content = self.Gather_Content
         print(f"Web浏览器模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
@@ -55,6 +56,7 @@ class MpsWeb(WxGather):
             # 随机暂停几秒，避免过快的请求导致过快的被查到
             time.sleep(random.randint(0,interval))
             try:
+                callback_results = []
                 headers = self.fix_header(url)
                 resp = session.get(url, headers=headers, params = params, verify=False, timeout=(10, 30))
                 
@@ -106,10 +108,13 @@ class MpsWeb(WxGather):
                                     item["id"] = item["aid"]
                                     item["mp_id"] = Mps_id
                                     if CallBack is not None:
-                                        super().FillBack(CallBack=CallBack,data=item,Ext_Data={"mp_title":Mps_title,"mp_id":Mps_id})
+                                        callback_results.append(super().FillBack(CallBack=CallBack,data=item,Ext_Data={"mp_title":Mps_title,"mp_id":Mps_id}))
                     print(f"第{i+1}页爬取成功\n")
                 # 翻页
                 i += 1
+                if should_stop_after_page(callback_results, StopOnExisting):
+                    print("检测到已存在文章，停止自动翻页")
+                    break
             except requests.exceptions.Timeout:
                 print("Request timed out")
                 break

--- a/driver/anti_crawler_config.py
+++ b/driver/anti_crawler_config.py
@@ -30,8 +30,7 @@ class AntiCrawlerConfig:
             "zh-CN,zh;q=0.9,en;q=0.8",
             "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2",
             "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7"
-        ],
-        'cache_control': ["no-cache", "max-age=0", "no-store"]
+        ]
     }
     
     # 时区配置
@@ -94,8 +93,11 @@ class AntiCrawlerConfig:
             "Accept": random.choice(self.HEADERS['accept']),
             "Accept-Language": random.choice(self.HEADERS['accept_language']),
             "Accept-Encoding": "gzip, deflate, br",
-            "Cache-Control": random.choice(self.HEADERS['cache_control']),
-            "Upgrade-Insecure-Requests": "1",
+            # 注意：不能设置 Cache-Control 和 Upgrade-Insecure-Requests。
+            # extra_http_headers 会作用于页面发出的所有请求（包括XHR），
+            # 而真实浏览器只在页面导航请求上带这两个头；
+            # 带上后 mp.weixin.qq.com 登录页初始化失败，
+            # #app 一直保持 visibility:hidden，登录二维码无法加载
             "Sec-Fetch-Dest": "document",
             "Sec-Fetch-Mode": "navigate",
             "Sec-Fetch-Site": "none",

--- a/driver/chrome_path.py
+++ b/driver/chrome_path.py
@@ -1,0 +1,52 @@
+"""
+跨平台解析本地 Chromium 内核浏览器（Chrome / Edge / Chromium）可执行文件路径。
+
+设计目标：
+- 不写死任何机器专属绝对路径（如某台 Windows 的 D:\\Tools\\...）。
+- 跨平台：Win11 / Docker-Linux / macOS 均可用。
+- 默认“不启用”：解析不到时返回 None，由调用方回退到 Playwright 自带浏览器，
+  从而保持上游默认行为（默认 webkit）完全不变，Docker/Linux 零回归。
+
+解析优先级：
+  1. 环境变量 CHROME_EXECUTABLE_PATH（跨平台、最高优先级，用户显式指定）
+  2. 当前操作系统的“标准安装位置”自动发现（仅当文件确实存在时才采用）
+  3. 都没有 -> 返回 None
+"""
+import os
+import sys
+
+# 仅收录各平台“标准”安装位置；不含任何机器专属路径。
+# 找不到时列表自然跳过，返回 None（调用方回退自带浏览器）。
+_CANDIDATES = {
+    "win32": [
+        os.path.expandvars(r"%ProgramFiles%\Google\Chrome\Application\chrome.exe"),
+        os.path.expandvars(r"%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe"),
+        os.path.expandvars(r"%ProgramFiles%\Microsoft\Edge\Application\msedge.exe"),
+        os.path.expandvars(r"%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe"),
+    ],
+    "linux": [
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser",
+    ],
+    "darwin": [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    ],
+}
+
+
+def get_chrome_executable_path() -> "str | None":
+    """返回可用的 Chromium 内核浏览器可执行文件路径；无则返回 None。
+
+    返回 None 时，调用方应保持原有浏览器类型（如上游默认的 webkit），
+    由 Playwright 启动其自带浏览器，确保 Docker/Linux 默认行为不变。
+    """
+    env = os.environ.get("CHROME_EXECUTABLE_PATH")
+    if env and os.path.exists(env):
+        return env
+    for cand in _CANDIDATES.get(sys.platform, []):
+        if cand and os.path.exists(cand):
+            return cand
+    return None

--- a/driver/playwright_driver.py
+++ b/driver/playwright_driver.py
@@ -18,6 +18,7 @@ if sys.platform == 'win32':
 
 from core.print import print_error, print_info, print_warning
 from driver.anti_crawler_config import AntiCrawlerConfig
+from driver.chrome_path import get_chrome_executable_path
 
 @dataclass
 class Metrics:
@@ -54,7 +55,8 @@ class PlaywrightController:
                  proxy_url: Optional[str] = "",
                  user_agent: Optional[str] = None,
                  debug: bool = False,
-                 mobile_mode: bool = False):
+                 mobile_mode: bool = False,
+                 apply_anti_crawler: bool = True):
         """
         初始化异步控制器
 
@@ -72,6 +74,11 @@ class PlaywrightController:
         self.proxy_url = proxy_url
         self.debug = debug
         self.mobile_mode = mobile_mode
+        # 是否应用反爬虫注入（extra_http_headers + 反检测脚本）。
+        # 反爬头含 Cache-Control / Sec-Fetch-* 等非 CORS 安全头，会触发跨域预检，
+        # 导致部分站点（如微信公众平台登录页）自身 JS 资源加载失败、二维码无法渲染。
+        # 微信登录等场景需退化为普通浏览器，故提供关闭开关。
+        self.apply_anti_crawler = apply_anti_crawler
 
         # 反爬虫配置实例
         self.anti_crawler_config = AntiCrawlerConfig()
@@ -119,6 +126,15 @@ class PlaywrightController:
             # 启动 Playwright
             self._playwright = await async_playwright().start()
 
+            # ===== 本地 Chrome 支持（可选，避免强制 playwright install 下载浏览器）=====
+            # 仅当通过环境变量 CHROME_EXECUTABLE_PATH 显式指定（或自动发现到本机标准安装的
+            # Chromium 内核浏览器）时才启用；否则保持上游默认浏览器（默认 webkit，由 Playwright 自带），
+            # 跨平台可移植，Docker/Linux 默认行为不受影响。
+            CHROME_PATH = get_chrome_executable_path()
+            if CHROME_PATH:
+                self.browser_type = "chromium"
+                print_info(f"使用本地 Chrome: {CHROME_PATH}（跳过 Playwright 浏览器下载）")
+
             # 选择浏览器类型
             browser_launcher = getattr(self._playwright, self.browser_type)
 
@@ -138,6 +154,9 @@ class PlaywrightController:
                     "--disable-dev-shm-usage",
                     "--no-sandbox",
                 ]
+                # 使用本地 Chrome 可执行文件，避免下载 Playwright 浏览器
+                if CHROME_PATH:
+                    launch_options["executable_path"] = CHROME_PATH
 
             # 添加代理
             if self.proxy_url:
@@ -157,8 +176,8 @@ class PlaywrightController:
                 "timezone_id": "Asia/Shanghai",
             }
 
-            # 应用额外的HTTP头
-            if "extra_http_headers" in anti_config:
+            # 应用额外的HTTP头（反爬注入可能破坏跨域资源加载，关闭时跳过）
+            if self.apply_anti_crawler and "extra_http_headers" in anti_config:
                 context_options["extra_http_headers"] = anti_config["extra_http_headers"]
 
             # 应用其他可选配置
@@ -171,8 +190,9 @@ class PlaywrightController:
             # 创建页面
             self._page = await self._context.new_page()
 
-            # ========== 核心改造：注入反检测脚本 ==========
-            await self._apply_anti_crawler_scripts(self._page)
+            # ========== 核心改造：注入反检测脚本（关闭反爬时跳过）==========
+            if self.apply_anti_crawler:
+                await self._apply_anti_crawler_scripts(self._page)
 
             # 记录启动时间
             self.metrics.browser_startup_time = time.time() - start_time

--- a/driver/wx.py
+++ b/driver/wx.py
@@ -436,6 +436,38 @@ class Wx:
                 except Exception as e:
                     print(f"二维码图片获取失败: {str(e)}")
         return self.isLock
+    async def _wait_qrcode_ready(self, page, qr_tag, timeout=30):
+        """等待登录二维码图片加载完成（异步）
+
+        新版登录页可能默认展示"微信快捷登录"（open.weixin.qq.com iframe），
+        此时经典二维码处于隐藏状态且src为空，直接截图会得到空白图片或超时。
+        检测到该情况时点击"扫码登录"链接切换回二维码登录，
+        再等待二维码图片可见且真正加载完成。
+        """
+        import asyncio
+
+        deadline = time.time() + timeout
+        switch_clicked = False
+        while time.time() < deadline:
+            ready = await page.evaluate(
+                """(sel) => {
+                    const img = document.querySelector(sel);
+                    if (!img) return false;
+                    const style = window.getComputedStyle(img);
+                    if (style.display === 'none' || style.visibility === 'hidden') return false;
+                    return !!img.src && img.complete && img.naturalWidth > 50;
+                }""", qr_tag)
+            if ready:
+                return True
+            if not switch_clicked:
+                switch_link = page.locator("a.login__type__container__link_text", has_text="扫码登录")
+                if await switch_link.count() > 0 and await switch_link.first.is_visible():
+                    print_info("检测到快捷登录页面，切换到扫码登录...")
+                    await switch_link.first.click()
+                    switch_clicked = True
+            await asyncio.sleep(0.5)
+        return False
+
     async def wxLogin(self, CallBack=None, NeedExit=True):
         """
         微信公众平台登录流程（异步）：
@@ -474,11 +506,20 @@ class Wx:
             page = driver.page
 
             # 等待页面完全加载
+            # 新版登录页存在持续的轮询请求，networkidle可能永远不触发，
+            # 超时不视为错误，由后续二维码加载检测兜底
             print_info("正在加载登录页面...")
-            await page.wait_for_load_state("networkidle")
+            try:
+                await page.wait_for_load_state("networkidle", timeout=10000)
+            except Exception:
+                pass
 
             # 定位二维码区域
             qr_tag = ".login__type__container__scan__qrcode"
+            # 新版登录页可能默认展示"微信快捷登录"，二维码被隐藏或src为空，
+            # 需要先切换回扫码登录并等待二维码图片真正加载完成
+            if not await self._wait_qrcode_ready(page, qr_tag):
+                raise Exception("二维码加载超时，请重试")
             # 获取二维码图片URL
             qrcode = await page.query_selector(qr_tag)
             code_src = await qrcode.get_attribute("src")
@@ -503,7 +544,10 @@ class Wx:
                 if self.WX_HOME in current_url:
                     print(f"登录成功，正在获取cookie和token...")
             page.on('framenavigated', handle_frame_navigated)
-            await page.wait_for_event("framenavigated", timeout=5*60 * 1000)
+            # 只等待主页面跳转到公众平台首页，
+            # 不能用 wait_for_event("framenavigated")：页面内的快捷登录iframe
+            # 加载时也会触发该事件，导致未扫码就误判为登录成功
+            await page.wait_for_url(lambda url: "cgi-bin/home" in url, timeout=5*60 * 1000)
 
             from .success import setStatus
             with self._login_lock:

--- a/jobs/failauth.py
+++ b/jobs/failauth.py
@@ -1,4 +1,4 @@
-from core.print import print_warning
+from core.print import print_warning, print_info
 from driver.base import WX_API
 from core.config import cfg
 from jobs.notice import sys_notice
@@ -6,22 +6,59 @@ from driver.success import Success
 from tools.base64_tools import image_to_base64
 import time
 
-def send_wx_code(title:str="",url:str=""):
-    if cfg.get("server.send_code",False):
-        WX_API.GetCode(Notice=CallBackNotice,CallBack=Success)
-    pass
-def CallBackNotice(data=None,ext_data=None):
-        if data is not None:
-            print_warning(data)
-            return 
-        img_path=WX_API.QRcode()['code']
-        rss_domain=str(cfg.get("rss.base_url",""))
-        url=rss_domain+str(img_path)
-        url=image_to_base64("./static/wx_qrcode.png")
-        text=f"- 服务名：{cfg.get('server.name','')}\n"
-        text+=f"- 发送时间： {time.strftime('%Y-%m-%d %H:%M:%S',time.localtime(time.time()))}"
-        if WX_API.GetHasCode():
-            text+=f"![描述]({url})"
-            # text+=f"<img src='{url}' width='100' height='100'/>"
-            text+=f"\n- 请使用微信扫描二维码进行授权"
-        sys_notice(text, str(cfg.get("server.code_title","WeRss授权过期,扫码授权")))
+
+def send_wx_code(title: str = "", url: str = ""):
+    """发送微信授权过期通知
+
+    始终发送过期通知。当 send_code=True 时，尝试获取二维码并附带在通知中；
+    当 send_code=False 时，只发送文字通知（不含二维码）。
+    """
+    # 始终发送过期通知（不依赖 send_code 配置）
+    text = f"- 服务名：{cfg.get('server.name', '')}\n"
+    text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}\n"
+    if title:
+        text += f"- 原因：{title}\n"
+
+    notice_title = str(cfg.get("server.code_title", "WeRss授权过期,扫码授权"))
+
+    if cfg.get("server.send_code", False):
+        # send_code=True: 尝试获取二维码，通过回调发送含二维码的通知
+        WX_API.GetCode(Notice=CallBackNotice, CallBack=Success)
+    else:
+        # send_code=False: 直接发送不含二维码的文字通知
+        text += "- 请手动访问系统进行扫码登录"
+        try:
+            sys_notice(text=text, title=notice_title)
+            print_info(f"已发送授权过期通知(无二维码): {notice_title}")
+        except Exception as e:
+            print_warning(f"发送授权过期通知失败: {e}")
+
+
+def CallBackNotice(data=None, ext_data=None):
+    """获取二维码过程中的回调通知"""
+    if data is not None:
+        print_warning(data)
+        # 获取二维码出错时，发送不含二维码的通知提醒用户手动登录
+        text = f"- 服务名：{cfg.get('server.name', '')}\n"
+        text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}\n"
+        text += f"- 获取二维码失败：{data}\n"
+        text += "- 请手动访问系统进行扫码登录"
+        try:
+            sys_notice(
+                text=text,
+                title=str(cfg.get("server.code_title", "WeRss授权过期"))
+            )
+        except Exception as e:
+            print_warning(f"发送二维码获取失败通知失败: {e}")
+        return
+
+    img_path = WX_API.QRcode()['code']
+    rss_domain = str(cfg.get("rss.base_url", ""))
+    url = rss_domain + str(img_path)
+    url = image_to_base64("./static/wx_qrcode.png")
+    text = f"- 服务名：{cfg.get('server.name', '')}\n"
+    text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}"
+    if WX_API.GetHasCode():
+        text += f"![描述]({url})"
+        text += f"\n- 请使用微信扫描二维码进行授权"
+    sys_notice(text, str(cfg.get("server.code_title", "WeRss授权过期,扫码授权")))

--- a/jobs/fetch_no_article.py
+++ b/jobs/fetch_no_article.py
@@ -53,6 +53,9 @@ def fetch_articles_without_content():
                         print_error(f"获取文章 {article.title} 内容已被发布者删除")
                     else:
                         print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:8001/views/article/{article.id}")
+                        # 成功获取内容后，恢复原始状态（通常为 ACTIVE），释放 FETCHING 锁
+                        article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
+                        session.commit()
                 else:
                     # 获取失败，恢复状态以便后续重试
                     article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)

--- a/jobs/fetch_no_article.py
+++ b/jobs/fetch_no_article.py
@@ -52,7 +52,7 @@ def fetch_articles_without_content():
                     if article.status == DATA_STATUS.DELETED:
                         print_error(f"获取文章 {article.title} 内容已被发布者删除")
                     else:
-                        print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:8001/views/article/{article.id}")
+                        print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:{cfg.get('port', 8001)}/views/article/{article.id}")
                         # 成功获取内容后，恢复原始状态（通常为 ACTIVE），释放 FETCHING 锁
                         article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
                         session.commit()

--- a/jobs/mps.py
+++ b/jobs/mps.py
@@ -232,7 +232,7 @@ def add_job(feeds:list[Feed]=None,task:MessageTask=None,isTest=False):
     pass
 import json
 def get_feeds(task:MessageTask=None):
-     mps = json.loads(task.mps_id)
+     mps = json.loads(task.mps_id) if task.mps_id else []
      ids=",".join([item["id"]for item in mps])
      mps=wx_db.get_mps_list(ids)
      if len(mps)==0:

--- a/jobs/mps.py
+++ b/jobs/mps.py
@@ -11,6 +11,7 @@ from core.print import print_info,print_success,print_error
 from driver.wx import WX_API
 from driver.success import Success
 from core.redis_client import clear_env_exception
+from core.gather_pagination import normalize_catch_up_max_pages
 wx_db=db.Db(tag="任务调度")
 def fetch_all_article():
     print("开始更新")
@@ -68,7 +69,19 @@ def do_job(mp=None,task:MessageTask=None,isTest=False):
             else:
                 wx=WxGather().Model()
                 try:
-                    wx.get_Articles(mp.faker_id,CallBack=UpdateArticle,Mps_id=mp.id,Mps_title=mp.mp_name, MaxPage=1,Over_CallBack=Update_Over,interval=interval)
+                    max_pages = normalize_catch_up_max_pages(
+                        cfg.get("gather.catch_up_max_pages", 10)
+                    )
+                    wx.get_Articles(
+                        mp.faker_id,
+                        CallBack=UpdateArticle,
+                        Mps_id=mp.id,
+                        Mps_title=mp.mp_name,
+                        MaxPage=max_pages,
+                        Over_CallBack=Update_Over,
+                        interval=interval,
+                        StopOnExisting=True,
+                    )
                     success = True
                 except Exception as e:
                     print_error(f"获取文章失败 [{mp.mp_name}]: {e}")

--- a/jobs/webhook.py
+++ b/jobs/webhook.py
@@ -196,7 +196,8 @@ def call_webhook(hook: MessageWebHook, is_test: bool = False) -> str:
             hook.task.web_hook_url,
             data=payload,
             headers=headers,
-            cookies=cookies
+            cookies=cookies,
+            timeout=30
         )
         response.raise_for_status()
         return "Webhook调用成功"

--- a/tools/mdtools/pdf.py
+++ b/tools/mdtools/pdf.py
@@ -44,11 +44,13 @@
 """
 import asyncio
 import sys
+import os
 import atexit
 from typing import Optional, Dict, Any
 from pathlib import Path
 from playwright.async_api import async_playwright, Browser, Page, BrowserContext
 import logging
+from driver.chrome_path import get_chrome_executable_path
 
 # Windows 平台需要使用 ProactorEventLoop 以支持子进程
 # Playwright 需要启动浏览器子进程，必须使用 ProactorEventLoop
@@ -96,9 +98,17 @@ class WebToPDFConverter:
     async def _ensure_browser(self) -> Browser:
         """确保浏览器已启动"""
         if self._browser is None:
+            # ===== 本地 Chrome 支持（可选，避免强制 playwright install 下载浏览器）=====
+            # 仅当通过环境变量 CHROME_EXECUTABLE_PATH 指定（或自动发现到本机标准 Chromium 浏览器）时启用。
+            CHROME_PATH = get_chrome_executable_path()
+            if CHROME_PATH:
+                self.browser_type = "chromium"
             self._playwright = await async_playwright().start()
+            launch_kwargs = {"headless": self.headless}
+            if self.browser_type == "chromium" and CHROME_PATH:
+                launch_kwargs["executable_path"] = CHROME_PATH
             if self.browser_type == "chromium":
-                self._browser = await self._playwright.chromium.launch(headless=self.headless)
+                self._browser = await self._playwright.chromium.launch(**launch_kwargs)
             elif self.browser_type == "firefox":
                 self._browser = await self._playwright.firefox.launch(headless=self.headless)
             elif self.browser_type == "webkit":


### PR DESCRIPTION
## Problem

Scheduled article collection always fetched only the first WeChat publish page. After a longer authorization outage, high-frequency accounts could have more than five publish batches and older missed articles were never recovered.

## Changes

- Allow scheduled collection to scan multiple pages.
- Stop after fully processing the first page that contains an existing article.
- Add `GATHER.CATCH_UP_MAX_PAGES`, defaulting to 10 pages and clamped to 1-20.
- Apply the stop behavior consistently to web, app, and API gather modes.
- Preserve explicit/manual pagination behavior unless catch-up mode is enabled.
- Add focused pagination and wiring tests.

## Validation

- `python3 -m py_compile core/gather_pagination.py core/test_gather_pagination.py core/wx/base.py core/wx/model/web.py core/wx/model/app.py core/wx/model/api.py jobs/mps.py`
- `python3 -m unittest core.test_gather_pagination` (7 tests)
- `cd core/lax && python3 -m unittest test_template_parser.py` (9 tests)

## Configuration

No migration is required. The default limit is suitable for most deployments. Operators can override it with `GATHER.CATCH_UP_MAX_PAGES`; values above 20 are capped to reduce WeChat rate-limit risk.