### PR TITLE
Fix cursor advancement after failed article crawl

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -170,7 +170,7 @@ http://localhost:3000
 | `WEB_NAME` | `WeRSS微信公众号订阅助手` | 前端显示名称 |
 | `WERSS_AUTH_WEB` | `False` | 通过web方式授权 |
 | `BROWSER_TYPE` | `firefox` | 浏览器类型默认firefox |
-| `SEND_CODE` | `True` | 是否发送授权二维码通知 |
+| `SEND_CODE` | `False` | 过期通知中是否附带授权二维码（默认仅发送文字通知） |
 | `CODE_TITLE` | `WeRSS授权二维码` | 二维码通知标题 |
 | `ENABLE_JOB` | `True` | 是否启用定时任务 |
 | `AUTO_RELOAD` | `False` | 代码修改自动重启服务 |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -220,7 +220,7 @@ The following are the environment variable configurations supported in `config.y
 | `APP_NAME` | `we-mp-rss` | Application name |
 | `SERVER_NAME` | `we-mp-rss` | Server name |
 | `WEB_NAME` | `WeRSS微信公众号订阅助手` | Frontend display name |
-| `SEND_CODE` | `True` | Whether to send authorization QR code notifications |
+| `SEND_CODE` | `False` | Whether to send authorization QR code in expired notification (text-only notification by default) |
 | `CODE_TITLE` | `WeRSS授权二维码` | QR code notification title |
 | `ENABLE_JOB` | `True` | Whether to enable scheduled tasks |
 | `AUTO_RELOAD` | `False` | Auto-restart service on code changes |

--- a/apis/article.py
+++ b/apis/article.py
@@ -167,6 +167,8 @@ async def clean_orphan_articles(
                 message="清理无效文章失败"
             )
         )
+    finally:
+        session.close()
 
 
 @router.delete("/clean-old", summary="清理指定天数前的旧文章")

--- a/apis/article.py
+++ b/apis/article.py
@@ -15,7 +15,6 @@ from core.print import print_warning, print_info, print_error, print_success
 from core.cache import clear_cache_pattern
 from tools.fix import fix_article
 from core.article_content import sync_article_content
-from driver.wxarticle import WXArticleFetcher
 router = APIRouter(prefix=f"/articles", tags=["文章管理"])
 
 _refresh_tasks = {}
@@ -38,13 +37,11 @@ def _get_active_refresh_task(article_id: str):
 
 
 def _run_refresh_article_task_wrapper(task_id: str, article_id: str):
-    """包装器:在线程中运行 async 函数"""
-    import asyncio
-    asyncio.run(_run_refresh_article_task(task_id, article_id))
+    _run_refresh_article_task(task_id, article_id)
 
-async def _run_refresh_article_task(task_id: str, article_id: str):
+
+def _run_refresh_article_task(task_id: str, article_id: str):
     session = DB.get_session()
-    fetcher = None
     try:
         _set_refresh_task(task_id, {
             "task_id": task_id,
@@ -63,48 +60,26 @@ async def _run_refresh_article_task(task_id: str, article_id: str):
             })
             return
 
-        target_url = (article.url or "").strip()
-        if not target_url:
+        updated, fetch_mode = sync_article_content(
+            session=session,
+            article=article,
+            preferred_mode=cfg.get("gather.content_mode", "web"),
+            force=True,
+        )
+        if not updated:
             _set_refresh_task(task_id, {
                 "task_id": task_id,
                 "article_id": article_id,
                 "status": "failed",
-                "message": "文章缺少可抓取链接"
+                "message": f"文章刷新失败: {fetch_mode}"
             })
             return
-
-        fetcher = WXArticleFetcher()
-        fetched = await fetcher.get_article_content(target_url)
-        fetched_content = fetched.get("content")
-        article.show_type=fetched.get("article_type",article.show_type )
-        if fetched_content != "DELETED" and not fetched_content:
-            fetch_error = fetched.get("fetch_error") or "文章内容抓取为空"
-            _set_refresh_task(task_id, {
-                "task_id": task_id,
-                "article_id": article_id,
-                "status": "failed",
-                "message": f"文章刷新失败: {fetch_error}"
-            })
-            return
-
-        article.title = fetched.get("title") or article.title
-        article.url = target_url
-        article.publish_time = fetched.get("publish_time") or article.publish_time
-        article.content = fetched_content if fetched_content is not None else article.content
-        if fetched_content == "DELETED":
-            article.description = fetched.get("description") or article.description
-        else:
-            article.description = fetched.get("description") or article.description
-        article.pic_url = fetched.get("topic_image") or fetched.get("pic_url") or article.pic_url
-        article.status = DATA_STATUS.DELETED if fetched_content == "DELETED" else DATA_STATUS.ACTIVE
-        # 更新 has_content 字段
-        article.has_content = 1 if (article.content and article.content.strip()) else 0
 
         now_seconds = int(time.time())
-        now_millis = int(time.time() * 1000)
         article.updated_at = now_seconds
-        article.updated_at_millis = now_millis
+        article.updated_at_millis = int(time.time() * 1000)
         session.commit()
+        session.refresh(article)
 
         clear_cache_pattern("articles_list")
         clear_cache_pattern("article_detail")
@@ -115,7 +90,12 @@ async def _run_refresh_article_task(task_id: str, article_id: str):
             "task_id": task_id,
             "article_id": article_id,
             "status": "success",
-            "message": "文章刷新成功",
+            "message": (
+                "文章已被发布者删除"
+                if article.status == DATA_STATUS.DELETED
+                else "文章刷新成功"
+            ),
+            "fetch_mode": fetch_mode,
             "updated_at": now_seconds
         })
     except Exception as e:

--- a/apis/auth.py
+++ b/apis/auth.py
@@ -22,6 +22,7 @@ from .base import success_response, error_response
 from driver.base import WX_API
 from core.config import set_config, cfg
 from core.print import print_warning
+from core.switch_job import get_manager as get_switch_job_manager
 from pydantic import BaseModel
 from typing import Optional
 
@@ -425,30 +426,163 @@ async def reset_password(req: ResetPasswordRequest):
         )
 
 
-@router.post("/switch", summary="切换微信账号")
-async def switch_wechat_account(current_user: dict = Depends(get_current_user)):
+@router.post("/switch", summary="切换微信账号（异步任务）")
+async def switch_wechat_account(
+    current_user: dict = Depends(get_current_user),
+    username: str = "",
+):
     """
-    切换微信公众号账号
+    异步触发切换微信公众号账号，立即返回 job_id。
 
     用法示例：
     ```
-    POST /api/v1/auth/switch
+    POST /api/v1/auth/switch?username=
     Authorization: Bearer {token}
+
+    # 轮询进度
+    GET /api/v1/auth/switch/status?job_id=<job_id>
+
+    # SSE 实时推送
+    GET /api/v1/auth/switch/progress?job_id=<job_id>
+    ```
+
+    设计要点：
+    * 实际切换流程（启动浏览器、点击切换按钮、轮询等待）可能耗时 30~120 秒，
+      因此改在后台线程执行；HTTP 接口立即返回。
+    * 切换期间已自动暂停抓取 / 内容任务队列，结束后自动恢复。
+    * Token 失效时立即返回 ok=false 与阶段消息，前端可据此引导用户重新扫码。
+    """
+    import asyncio
+    user_id = current_user.get("sub") or current_user.get("username") or current_user.get("id") or "unknown"
+    manager = get_switch_job_manager()
+    job = manager.create_job(user_id=str(user_id), target_username=username)
+    manager.update(job.job_id, stage="queued", message="已入队，准备启动切换任务", progress=0)
+
+    def _run_in_thread() -> None:
+        """在新线程中跑同步包装，确保 HTTP 立即返回。"""
+        import threading
+        def _target() -> None:
+            try:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                # Windows 需要 ProactorEventLoop 给 Playwright 用
+                import sys
+                if sys.platform == "win32":
+                    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+                try:
+                    def progress_callback(stage: str, message: str, progress: int) -> None:
+                        manager.update(job.job_id, stage=stage, message=message, progress=progress)
+                    result = loop.run_until_complete(
+                        WX_API.switch_account(username=username, progress_callback=progress_callback)
+                    )
+                    manager.finish(job.job_id, ok=bool(result), message=("切换成功" if result else "切换失败，详情请查看日志"))
+                finally:
+                    try:
+                        loop.close()
+                    except Exception:
+                        pass
+            except Exception as e:
+                manager.finish(job.job_id, ok=False, message=f"后台任务异常: {e}")
+        threading.Thread(target=_target, daemon=True).start()
+
+    _run_in_thread()
+    return success_response(job.to_dict(), "切换任务已启动，可通过 job_id 查询进度")
+
+
+@router.get("/switch/status", summary="查询切换账号任务状态")
+async def switch_status(
+    job_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """根据 job_id 返回当前阶段、消息、进度、是否完成。仅 job 所有者可访问。"""
+    job = get_switch_job_manager().get_job(job_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=error_response(code=40404, message=f"找不到切换任务 {job_id}"),
+        )
+    caller_id = str(
+        current_user.get("sub")
+        or current_user.get("username")
+        or current_user.get("id")
+        or ""
+    )
+    if job.user_id != caller_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=error_response(code=40303, message="无权访问该切换任务"),
+        )
+    return success_response(job.to_dict(), "ok")
+
+
+@router.get("/switch/progress", summary="SSE 实时推送切换账号进度")
+async def switch_progress(
+    job_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Server-Sent Events 流式推送，仅 job 所有者可订阅。
+
+    事件格式（每行 JSON）：
+    ```
+    data: {"job_id":"abc...","stage":"clicking","message":"...","progress":65,"ok":null,"started_at":...,"finished_at":null}
     ```
     """
     import asyncio
+    import json
+    from fastapi.responses import StreamingResponse
 
-    try:
-        # 调用切换账号方法（异步）
-        result = await WX_API.switch_account()
-        return success_response(result, "切换账号成功" if result else "切换账号失败")
-    except HTTPException:
-        raise
-    except Exception as e:
+    # 先做鉴权 + 所有权校验，避免给未授权 SSE 长连接
+    job = get_switch_job_manager().get_job(job_id)
+    if job is None:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_response(code=50001, message=f"切换账号失败: {str(e)}")
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=error_response(code=40404, message=f"找不到切换任务 {job_id}"),
         )
+    caller_id = str(
+        current_user.get("sub")
+        or current_user.get("username")
+        or current_user.get("id")
+        or ""
+    )
+    if job.user_id != caller_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=error_response(code=40303, message="无权订阅该切换任务进度"),
+        )
+
+    async def event_stream():
+        try:
+            manager = get_switch_job_manager()
+            q = await manager.subscribe(job_id)
+        except KeyError:
+            yield "event: error\ndata: {\"message\":\"job not found\"}\n\n"
+            return
+        try:
+            while True:
+                try:
+                    snap = await asyncio.wait_for(q.get(), timeout=15.0)
+                except asyncio.TimeoutError:
+                    # 心跳保活
+                    yield "event: ping\ndata: {}\n\n"
+                    continue
+                yield f"data: {json.dumps(snap, ensure_ascii=False)}\n\n"
+                if snap.get("finished_at") is not None:
+                    break
+        finally:
+            try:
+                get_switch_job_manager().unsubscribe(job_id, q)
+            except Exception:
+                pass
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
 
 
 @router.post("/wechat/unbind", summary="解除微信授权")

--- a/apis/auth.py
+++ b/apis/auth.py
@@ -21,6 +21,7 @@ from .ver import API_VERSION
 from .base import success_response, error_response
 from driver.base import WX_API
 from core.config import set_config, cfg
+from core.print import print_warning
 from pydantic import BaseModel
 from typing import Optional
 
@@ -428,7 +429,7 @@ async def reset_password(req: ResetPasswordRequest):
 async def switch_wechat_account(current_user: dict = Depends(get_current_user)):
     """
     切换微信公众号账号
-    
+
     用法示例：
     ```
     POST /api/v1/auth/switch
@@ -447,4 +448,57 @@ async def switch_wechat_account(current_user: dict = Depends(get_current_user)):
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=error_response(code=50001, message=f"切换账号失败: {str(e)}")
+        )
+
+
+@router.post("/wechat/unbind", summary="解除微信授权")
+async def unbind_wechat(current_user: dict = Depends(get_current_user)):
+    """
+    解除当前已绑定的微信公众号授权，删除本地 token 与 Redis 缓存。
+
+    用法示例：
+    ```
+    POST /api/v1/auth/wechat/unbind
+    Authorization: Bearer {token}
+    ```
+
+    解除后下次调用 `/api/v1/auth/qr/code` 时会自动引导重新扫码授权。
+    """
+    try:
+        # 1. 清除本地 token 文件
+        from driver.token import wx_cfg
+        wx_cfg.set("token_data", {})
+        wx_cfg.save_config()
+        wx_cfg.reload()
+
+        # 2. 清除 Redis 中的 token 与登录状态（仅作用于 werss 前缀键）
+        from core.redis_client import redis_client
+        cleared_keys: list = []
+        if redis_client.is_connected:
+            try:
+                for key in redis_client._client.keys("werss:token:*"):
+                    redis_client._client.delete(key)
+                    cleared_keys.append(key.decode() if isinstance(key, bytes) else key)
+                redis_client._client.set("werss:login:status", "0")
+            except Exception as e:
+                print_warning(f"清理 Redis token 时出错: {e}")
+
+        # 3. 同步全局登录状态（内存回退）
+        from driver.success import setStatus
+        setStatus(False)
+
+        return success_response(
+            {
+                "cleared_local_token": True,
+                "cleared_redis_keys": cleared_keys,
+                "next_step": "请重新扫码授权",
+            },
+            "微信授权已解除",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=error_response(code=50002, message=f"解除微信授权失败: {str(e)}"),
         )

--- a/apis/message_task.py
+++ b/apis/message_task.py
@@ -199,8 +199,12 @@ async def run_message_task(
             import json
             for task in tasks:
                 try:
-                    ids=json.loads(task.mps_id)
-                    count+=len(ids)
+                    # mps_id 可能为空（UI 提示"留空则对所有公众号生效"），
+                    # 通过 get_feeds() 拿实际 feed 数，与 jobs/mps.py 一致
+                    from jobs.mps import get_feeds
+                    feeds = get_feeds(task)
+                    ids = [{"id": f.id, "name": f.mp_name} for f in feeds]
+                    count += len(ids)
                     mps['count']=count
                     mps['list'].append(ids)
                 except Exception as e:

--- a/apis/message_task.py
+++ b/apis/message_task.py
@@ -1,3 +1,4 @@
+import asyncio
 from pydantic import BaseModel
 
 # 标准导入分组和顺序
@@ -148,7 +149,7 @@ async def test_message_task(
             articles=mock_articles  # type: ignore
         )
         
-        result = web_hook(test_hook, is_test=True)
+        result = await asyncio.to_thread(web_hook, test_hook, is_test=True)
         
         return success_response(
             data={

--- a/apis/tools.py
+++ b/apis/tools.py
@@ -6,10 +6,11 @@ from core.auth import get_current_user_or_ak
 from core.db import DB
 from .base import success_response, error_response,BaseResponse
 from datetime import datetime
-from typing import Optional, List, Literal
+from typing import Optional, List, Literal, Any
 import os
 import threading
 import asyncio
+import zipfile
 from concurrent.futures import ThreadPoolExecutor
 import io
 import uuid
@@ -87,58 +88,235 @@ def _export_articles_worker(
         zip_filename=zip_filename
     )
 
-@router.post("/export/articles", summary="导出文章")
+@router.post("/export/articles", summary="导出文章（异步任务）")
 async def export_articles(
     request: ExportArticlesRequest,
     current_user: dict = Depends(get_current_user_or_ak)
 ):
     """
-    导出文章为多种格式（使用线程池异步处理）
+    异步导出文章，立即返回 job_id，通过 job_id 查询进度或订阅 SSE。
+
+    用法示例：
+    ```
+    POST /api/v1/wx/tools/export/articles
+    Authorization: Bearer {token}
+
+    # 轮询
+    GET /api/v1/wx/tools/export/status?job_id=<job_id>
+
+    # SSE
+    GET /api/v1/wx/tools/export/progress?job_id=<job_id>
+    ```
     """
     try:
-        # 检查是否已有相同 mp_id 的导出任务正在运行
+        # 已有同名导出任务则拒绝，避免并发执行
         for thread in threading.enumerate():
             if thread.name == f"export_articles_{request.mp_id}":
                 return error_response(400, "该公众号的导出任务已在处理中，请勿重复点击")
-                
-        # 直接生成 zip_filename 并返回
+
         docx_path = f"./data/docs/{request.mp_id}/"
         if request.zip_filename:
             zip_file_path = f"{docx_path}{request.zip_filename}"
         else:
             zip_file_path = f"{docx_path}exported_articles_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
-        
-        # 启动后台线程执行导出操作
-        export_thread = threading.Thread(
-            target=_export_articles_worker,
-            args=(
-                request.mp_id,
-                request.doc_id,
-                request.page_size,
-                request.page_count,
-                request.add_title,
-                request.remove_images,
-                request.remove_links,
-                request.export_md,
-                request.export_docx,
-                request.export_json,
-                request.export_csv,
-                request.export_pdf,
-                request.zip_filename
-            ),
-            name=f"export_articles_{request.mp_id}"
+
+        # 注册后台任务并立即返回 job_id
+        from core.export_job import get_export_job_manager
+        user_id = current_user.get("sub") or current_user.get("username") or current_user.get("id") or "unknown"
+        active_fmts = [
+            name for name, enabled in (
+                ("md", request.export_md), ("docx", request.export_docx),
+                ("json", request.export_json), ("csv", request.export_csv),
+                ("pdf", request.export_pdf),
+            ) if enabled
+        ]
+        manager = get_export_job_manager()
+        job = manager.create_job(
+            user_id=str(user_id),
+            mp_id=request.mp_id,
+            fmt_summary="+".join(active_fmts) or "none",
         )
-        export_thread.start()
-        
+        manager.update(job.job_id, stage="queued", message="任务已入队", progress=0,
+                       output_path=zip_file_path)
+
+        def _run() -> None:
+            """后台线程：调用优化版 exporter 并打包。"""
+            try:
+                from core.exporter import _export_articles_optimized
+                from core.db import DB
+                session = DB.get_session()
+
+                def progress_cb(stage: str, message: str, progress: int, **kw: Any) -> None:
+                    manager.update(job.job_id, stage=stage, message=message, progress=progress, **kw)
+
+                # 1) 渲染各类格式文件
+                result = _export_articles_optimized(
+                    session=session,
+                    mp_id=request.mp_id,
+                    doc_id=request.doc_id,
+                    page_size=request.page_size,
+                    page_count=request.page_count,
+                    add_title=request.add_title,
+                    remove_images=request.remove_images,
+                    remove_links=request.remove_links,
+                    export_md=request.export_md,
+                    export_docx=request.export_docx,
+                    export_json=request.export_json,
+                    export_csv=request.export_csv,
+                    export_pdf=request.export_pdf,
+                    docx_path=docx_path,
+                    progress_callback=progress_cb,
+                )
+                processed = result.get("processed", 0)
+                skipped = result.get("skipped", 0)
+
+                # 2) 打包 zip + 删除源文件
+                if processed > 0:
+                    manager.update(job.job_id, stage="packaging", message="正在打包…", progress=92)
+                    try:
+                        final_zip = zip_file_path
+                        if not final_zip.endswith(".zip"):
+                            final_zip += ".zip"
+                        if os.path.exists(final_zip):
+                            os.remove(final_zip)
+                        with zipfile.ZipFile(final_zip, "w", zipfile.ZIP_DEFLATED) as zf:
+                            for root, _, files in os.walk(docx_path):
+                                for f in files:
+                                    if f.endswith(".zip"):
+                                        continue
+                                    fp = os.path.join(root, f)
+                                    arc = os.path.relpath(fp, docx_path)
+                                    zf.write(fp, arc)
+                                    try:
+                                        os.remove(fp)
+                                    except Exception as e:
+                                        print_error(f"删除文件失败 {fp}: {e}")
+                        manager.finish(
+                            job.job_id, ok=True,
+                            message=f"导出完成：共 {processed} 篇（跳过 {skipped} 篇）",
+                            output_path=final_zip,
+                        )
+                    except Exception as e:
+                        manager.finish(job.job_id, ok=False, message=f"打包失败: {e}")
+                else:
+                    manager.finish(
+                        job.job_id, ok=False,
+                        message=f"没有可导出的文章（跳过 {skipped} 篇）",
+                    )
+
+            except Exception as e:
+                manager.finish(job.job_id, ok=False, message=f"后台导出异常: {e}")
+
+        threading.Thread(target=_run, name=f"export_articles_{request.mp_id}", daemon=True).start()
+
+        # 返回时不要泄露服务器绝对路径，只给文件名（下载 API 会基于 mp_id 拼接）
         return success_response({
-            "export_path": zip_file_path,
-            "message": "导出任务已启动，请稍后下载文件"
-        })
-            
+            "job_id": job.job_id,
+            "export_path": os.path.basename(zip_file_path),
+            "mp_id": request.mp_id,
+            "message": "导出任务已启动，请通过 job_id 查询进度或订阅 SSE",
+        }, "导出任务已启动")
+
     except ValueError as e:
         return error_response(400, str(e))
     except Exception as e:
         return error_response(500, f"导出失败: {str(e)}")
+
+
+@router.get("/export/status", summary="查询文章导出任务状态")
+async def export_status(
+    job_id: str,
+    current_user: dict = Depends(get_current_user_or_ak),
+):
+    """根据 job_id 返回当前阶段、消息、进度、总数、已处理数、跳过数。仅 job 所有者可访问。"""
+    from core.export_job import get_export_job_manager
+    job = get_export_job_manager().get_job(job_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=error_response(code=40404, message=f"找不到导出任务 {job_id}"),
+        )
+    caller_id = str(
+        current_user.get("sub")
+        or current_user.get("username")
+        or current_user.get("id")
+        or ""
+    )
+    if job.user_id != caller_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=error_response(code=40303, message="无权访问该导出任务"),
+        )
+    return success_response(job.to_dict(), "ok")
+
+
+@router.get("/export/progress", summary="SSE 实时推送文章导出进度")
+async def export_progress(
+    job_id: str,
+    current_user: dict = Depends(get_current_user_or_ak),
+):
+    """Server-Sent Events 流式推送，仅 job 所有者可订阅。
+
+    事件格式（每行 JSON）：
+    ```
+    data: {"job_id":"abc...","stage":"rendering_pdfs","message":"...","progress":40,"total_records":25,"processed_records":8,"skipped_records":2,"ok":null,"started_at":...,"finished_at":null}
+    ```
+    """
+    from core.export_job import get_export_job_manager
+    from fastapi.responses import StreamingResponse
+    import asyncio
+    import json as json_lib
+
+    job = get_export_job_manager().get_job(job_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=error_response(code=40404, message=f"找不到导出任务 {job_id}"),
+        )
+    caller_id = str(
+        current_user.get("sub")
+        or current_user.get("username")
+        or current_user.get("id")
+        or ""
+    )
+    if job.user_id != caller_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=error_response(code=40303, message="无权订阅该导出任务进度"),
+        )
+
+    async def event_stream():
+        try:
+            manager = get_export_job_manager()
+            q = await manager.subscribe(job_id)
+        except KeyError:
+            yield "event: error\ndata: {\"message\":\"job not found\"}\n\n"
+            return
+        try:
+            while True:
+                try:
+                    snap = await asyncio.wait_for(q.get(), timeout=15.0)
+                except asyncio.TimeoutError:
+                    yield "event: ping\ndata: {}\n\n"
+                    continue
+                yield f"data: {json_lib.dumps(snap, ensure_ascii=False)}\n\n"
+                if snap.get("finished_at") is not None:
+                    break
+        finally:
+            try:
+                get_export_job_manager().unsubscribe(job_id, q)
+            except Exception:
+                pass
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
 
 @router.get("/export/download", summary="下载导出文件")
 async def download_export_file(

--- a/config-node.yaml
+++ b/config-node.yaml
@@ -4,8 +4,8 @@ server:
    name: ${SERVER_NAME:-we-mp-rss}
    #前端显示名称
    web_name: ${WEB_NAME:-WeRSS微信公众号订阅助手}
-   #过期是否发送授权二维通知 默认True
-   send_code: ${SEND_CODE:-True}
+   #过期是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${SEND_CODE:-False}
    #二维通知标题
    code_title: ${CODE_TITLE:-WeRSS}
    #启动JOB定时任务，默认为True
@@ -16,8 +16,8 @@ server:
    threads: ${THREADS:-1}
    #通过web方式授权二维码 默认False 
    auth_web: ${WERSS_AUTH_WEB:-False}
-   #是否发送授权二维通知 默认True
-   send_code: ${WERSS_SEND_CODE:-True}
+   #是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${WERSS_SEND_CODE:-False}
 
 
 #数据库连接 例如db:  mysql+pymysql://<username>:<password>@<host>/we-rss?charset=utf8mb4

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,8 +4,8 @@ server:
    name: ${SERVER_NAME:-we-mp-rss}
    #前端显示名称
    web_name: ${WEB_NAME:-WeRSS微信公众号订阅助手}
-   #过期是否发送授权二维通知 默认True
-   send_code: ${SEND_CODE:-True}
+   #过期是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${SEND_CODE:-False}
    #二维通知标题
    code_title: ${CODE_TITLE:-WeRSS}
    #启动JOB定时任务，默认为True
@@ -16,8 +16,8 @@ server:
    threads: ${THREADS:-1}
    #通过web方式授权二维码 默认False 
    auth_web: ${WERSS_AUTH_WEB:-False}
-   #是否发送授权二维通知 默认True
-   send_code: ${WERSS_SEND_CODE:-True}
+   #是否发送授权二维码通知 默认False，设为True时通知中附带二维码
+   send_code: ${WERSS_SEND_CODE:-False}
    #是否启用自动刷新文章统计 默认False
    article_stats_refresh_enabled: ${ARTICLE_STATS_REFRESH_ENABLED:-False}
    # 文章统计刷新间隔 默认300秒

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -132,7 +132,17 @@ gather:
   content_auto_interval: ${GATHER.CONTENT_AUTO_INTERVAL:-59}
   #内容修正模式，默认web 允许值 web、api
   content_mode: ${GATHER.CONTENT_MODE:-web}
-  #是否清理html标签 默认True 
+  #单篇正文抓取总超时（秒），超时会终止浏览器进程并释放文章锁
+  content_fetch_timeout: ${GATHER.CONTENT_FETCH_TIMEOUT:-60}
+  #FETCHING锁超过该时间（秒）后自动恢复；历史无时间戳锁也会恢复
+  content_fetch_stale_timeout: ${GATHER.CONTENT_FETCH_STALE_TIMEOUT:-300}
+  #每轮补抓文章数量，避免超过内容队列的总任务超时
+  content_batch_size: ${GATHER.CONTENT_BATCH_SIZE:-5}
+  #单篇正文最大失败次数
+  content_max_failures: ${GATHER.CONTENT_MAX_FAILURES:-3}
+  #首选模式失败后是否回退到另一模式；设为False可启用api-only
+  content_fallback: ${GATHER.CONTENT_FALLBACK:-True}
+  #是否清理html标签 默认True
   clean_html: ${GATHER.CLEAN_HTML:-False}
   #浏览器类型 默认firefox 允许值 firefox/edge/webkit
   browser_type: ${BROWSER_TYPE:-firefox}

--- a/core/article_content.py
+++ b/core/article_content.py
@@ -5,6 +5,11 @@ from typing import Any, Tuple
 from core.config import cfg
 from core.models.base import DATA_STATUS
 from core.print import print_info, print_warning
+from core.process_timeout import (
+    ProcessExecutionError,
+    ProcessExecutionTimeout,
+    run_in_process,
+)
 
 
 def normalize_content_mode(mode: str | None = None) -> str:
@@ -55,9 +60,17 @@ def _fetch_with_api(url: str) -> Tuple[str, Any]:
     return (fetcher.content_extract(url) or "").strip(),{}
 
 
-def fetch_article_content(url: str, preferred_mode: str | None = None) -> Tuple[str, str,str]:
+def _fetch_article_content_unbounded(
+    url: str,
+    preferred_mode: str | None = None,
+    allow_fallback: bool = True,
+) -> Tuple[str, str, str]:
     mode = normalize_content_mode(preferred_mode)
-    modes = [mode] + [item for item in ("web", "api") if item != mode]
+    modes = [mode]
+    if allow_fallback:
+        modes += [item for item in ("web", "api") if item != mode]
+
+    article_type = ""
 
     for current_mode in modes:
         try:
@@ -65,7 +78,6 @@ def fetch_article_content(url: str, preferred_mode: str | None = None) -> Tuple[
                 content,result = _fetch_with_api(url)
             else:
                 content,result = _fetch_with_web(url)
-            print(result)
             article_type = result.get("article_type", "")
         except Exception as exc:
             print_warning(f"fetch article content failed in {current_mode} mode: {exc}")
@@ -76,7 +88,44 @@ def fetch_article_content(url: str, preferred_mode: str | None = None) -> Tuple[
         if content:
             return content, current_mode,article_type
 
-    return "", mode,article_type
+    return "", mode, article_type
+
+
+def fetch_article_content(
+    url: str,
+    preferred_mode: str | None = None,
+    timeout: float | None = None,
+) -> Tuple[str, str, str]:
+    """Fetch article content in an isolated process with a hard timeout."""
+    fetch_timeout = float(timeout or cfg.get("gather.content_fetch_timeout", 60) or 60)
+    allow_fallback = bool(cfg.get("gather.content_fallback", True))
+    return run_in_process(
+        _fetch_article_content_unbounded,
+        url,
+        preferred_mode,
+        allow_fallback,
+        timeout=fetch_timeout,
+    )
+
+
+def mark_article_fetch_failed(session, article: Any, reason: str) -> None:
+    failures = int(getattr(article, "fix_fail_count", 0) or 0) + 1
+    max_failures = int(cfg.get("gather.content_max_failures", 3) or 3)
+    has_existing_content = bool((getattr(article, "content", "") or "").strip())
+    article.fix_fail_count = failures
+    article.has_content = 1 if has_existing_content else 0
+    if hasattr(article, "fetch_started_at"):
+        article.fetch_started_at = None
+    article.status = (
+        DATA_STATUS.FAILED
+        if failures >= max_failures and not has_existing_content
+        else DATA_STATUS.ACTIVE
+    )
+    session.commit()
+    print_warning(
+        f"article {getattr(article, 'id', '')} content fetch failed "
+        f"({failures}/{max_failures}): {reason}"
+    )
 
 
 def sync_article_content(
@@ -90,6 +139,9 @@ def sync_article_content(
         if getattr(article, "has_content", 0) == 0:
             print_info(f"article {article.id} already has content, skipping fetch")
             article.has_content = 1
+            article.status = DATA_STATUS.ACTIVE
+            if hasattr(article, "fetch_started_at"):
+                article.fetch_started_at = None
             session.commit()
             session.refresh(article)
             return True, "cached"
@@ -98,10 +150,24 @@ def sync_article_content(
     article_url = build_article_url(article)
     if not article_url:
         print_warning(f"article {getattr(article, 'id', '')} has no valid url")
+        mark_article_fetch_failed(session, article, "missing_url")
         return False, "missing_url"
 
-    content, mode, article_type = fetch_article_content(article_url, preferred_mode)
+    try:
+        content, mode, article_type = fetch_article_content(article_url, preferred_mode)
+    except ProcessExecutionTimeout as exc:
+        mark_article_fetch_failed(session, article, str(exc))
+        return False, "timeout"
+    except ProcessExecutionError as exc:
+        mark_article_fetch_failed(session, article, str(exc))
+        return False, "process_error"
+    except Exception as exc:
+        session.rollback()
+        mark_article_fetch_failed(session, article, str(exc))
+        return False, "error"
+
     if not content:
+        mark_article_fetch_failed(session, article, f"empty response via {mode}")
         return False, mode
 
     try:
@@ -110,6 +176,8 @@ def sync_article_content(
             article.content_html = ""
             article.status = DATA_STATUS.DELETED
             article.has_content = 0
+            if hasattr(article, "fetch_started_at"):
+                article.fetch_started_at = None
             session.commit()
             session.refresh(article)
             print_info(f"article {article.id} marked as deleted via {mode}")
@@ -123,6 +191,8 @@ def sync_article_content(
         article.show_type=article_type or article.show_type
         article.status = DATA_STATUS.ACTIVE
         article.has_content = 1
+        if hasattr(article, "fetch_started_at"):
+            article.fetch_started_at = None
         if not (getattr(article, "description", "") or "").strip():
             article.description = Web.get_description(content)
         # 修正成功,重置失败计数
@@ -132,13 +202,7 @@ def sync_article_content(
         session.refresh(article)
         print_info(f"article {article.id} content synced via {mode}")
         return True, mode
-    except Exception:
-        # 修正失败,增加失败计数
-        if hasattr(article, 'fix_fail_count'):
-            article.fix_fail_count = (article.fix_fail_count or 0) + 1
-            try:
-                session.commit()
-            except Exception:
-                session.rollback()
+    except Exception as exc:
         session.rollback()
-        raise
+        mark_article_fetch_failed(session, article, str(exc))
+        return False, "save_error"

--- a/core/article_content.py
+++ b/core/article_content.py
@@ -47,6 +47,34 @@ def build_article_url(article: Any) -> str:
     return f"https://mp.weixin.qq.com/s/{origin_id}"
 
 
+def is_usable_article_content(content: str | None) -> bool:
+    """Reject WeChat error/shell pages while allowing short media articles."""
+    if not (content or "").strip():
+        return False
+
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(content, "html.parser")
+    text = soup.get_text(" ", strip=True)
+    hard_error_markers = (
+        "未知错误，请稍后再试",
+        "你暂无权限查看此页面内容",
+        "当前环境异常，完成验证后即可继续访问",
+    )
+    if any(marker in text for marker in hard_error_markers):
+        return False
+
+    has_wechat_shell = (
+        "微信扫一扫可打开此内容" in text
+        and "使用完整服务" in text
+    )
+    meaningful_length = sum(character.isalnum() for character in text)
+    if has_wechat_shell and meaningful_length < 300:
+        return False
+
+    return bool(text) or soup.find(["img", "video", "audio", "iframe"]) is not None
+
+
 def _fetch_with_web(url: str) -> Tuple[str, Any]:
     from driver.wxarticle import Web
 
@@ -56,8 +84,20 @@ def _fetch_with_web(url: str) -> Tuple[str, Any]:
 
 def _fetch_with_api(url: str) -> Tuple[str, Any]:
     from core.wx.model.api import MpsApi
+
     fetcher = MpsApi()
-    return (fetcher.content_extract(url) or "").strip(),{}
+    response_html = (fetcher.content_extract(url) or "").strip()
+    if not response_html or response_html == "DELETED":
+        return response_html, {}
+
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(response_html, "html.parser")
+    article_body = soup.select_one("#js_content") or soup.select_one("#js_article")
+    if article_body is None:
+        print_warning("api response does not contain an article body")
+        return "", {}
+    return str(article_body), {}
 
 
 def _fetch_article_content_unbounded(
@@ -71,8 +111,10 @@ def _fetch_article_content_unbounded(
         modes += [item for item in ("web", "api") if item != mode]
 
     article_type = ""
+    last_mode = mode
 
     for current_mode in modes:
+        last_mode = current_mode
         try:
             if current_mode == "api":
                 content,result = _fetch_with_api(url)
@@ -85,10 +127,12 @@ def _fetch_article_content_unbounded(
 
         if content == "DELETED":
             return content, current_mode,article_type
-        if content:
+        if is_usable_article_content(content):
             return content, current_mode,article_type
+        if content:
+            print_warning(f"ignoring unusable article content from {current_mode} mode")
 
-    return "", mode, article_type
+    return "", last_mode, article_type
 
 
 def fetch_article_content(
@@ -111,7 +155,9 @@ def fetch_article_content(
 def mark_article_fetch_failed(session, article: Any, reason: str) -> None:
     failures = int(getattr(article, "fix_fail_count", 0) or 0) + 1
     max_failures = int(cfg.get("gather.content_max_failures", 3) or 3)
-    has_existing_content = bool((getattr(article, "content", "") or "").strip())
+    has_existing_content = is_usable_article_content(
+        getattr(article, "content", "")
+    )
     article.fix_fail_count = failures
     article.has_content = 1 if has_existing_content else 0
     if hasattr(article, "fetch_started_at"):
@@ -135,7 +181,7 @@ def sync_article_content(
     force: bool = False,
 ) -> Tuple[bool, str]:
     existing_content = (getattr(article, "content", "") or "").strip()
-    if existing_content and not force:
+    if is_usable_article_content(existing_content) and not force:
         if getattr(article, "has_content", 0) == 0:
             print_info(f"article {article.id} already has content, skipping fetch")
             article.has_content = 1

--- a/core/db.py
+++ b/core/db.py
@@ -123,6 +123,7 @@ class Db:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
     def delete_article(self,article_data:dict)->bool:
+        session = None
         try:
             art = Article(**article_data)
             if art.id: # type: ignore
@@ -136,9 +137,13 @@ class Db:
         except Exception as e:
             print_error(f"delete article:{str(e)}")
             pass      
+        finally:
+            if session is not None:
+                session.close()
         return False
      
     def add_article(self, article_data: dict,check_exist=True) -> bool:
+        session = None
         try:
             session=self.get_session()
             from datetime import datetime
@@ -194,48 +199,70 @@ class Db:
             session.add(art)
             print_info(f"Added article: {art.id}")
             sta=session.commit()
+            return True
         except Exception as e:
-            session.rollback()  # 回滚事务，确保session状态正常
+            if session:
+                session.rollback()  # 回滚事务，确保session状态正常
             if "UNIQUE" in str(e) or "Duplicate entry" in str(e):
                 print_warning(f"Article already exists: {art.id}")
             else:
                 print_error(f"Failed to add article: {e}")
             return False
-        return True    
-        
+        finally:
+            if session is not None:
+                session.close()
     def get_articles(self, id:str=None, limit:int=30, offset:int=0) -> List[Article]: # type: ignore
+        session = None
         try:
-            data = self.get_session().query(Article).limit(limit).offset(offset)
+            session = self.get_session()
+            data = session.query(Article).limit(limit).offset(offset)
             return data
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore   
+        finally:
+            if session is not None:
+                session.close()
              
     def get_all_mps(self) -> List[Feed]:
         """Get all Feed records"""
+        session = None
         try:
-            return self.get_session().query(Feed).all()
+            session = self.get_session()
+            return session.query(Feed).filter(Feed.status == 1).all()
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore
+        finally:
+            if session is not None:
+                session.close()
             
     def get_mps_list(self, mp_ids:str) -> List[Feed]:
+        session = None
         try:
             ids=mp_ids.split(',')
-            data =  self.get_session().query(Feed).filter(Feed.id.in_(ids)).all()
+            session = self.get_session()
+            data = session.query(Feed).filter(Feed.id.in_(ids)).all()
             return data
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore
+        finally:
+            if session is not None:
+                session.close()
     def get_mps(self, mp_id:str) -> Optional[Feed]:
+        session = None
         try:
             ids=mp_id.split(',')
-            data =  self.get_session().query(Feed).filter_by(id= mp_id).first()
+            session = self.get_session()
+            data = session.query(Feed).filter_by(id= mp_id).first()
             return data
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore
-
+        finally:
+            if session is not None:
+                session.close()
     def get_faker_id(self, mp_id:str):
         data = self.get_mps(mp_id)
         return data.faker_id # type: ignore

--- a/core/db.py
+++ b/core/db.py
@@ -69,6 +69,9 @@ class Db:
                 @event.listens_for(self.engine, "connect")
                 def set_sqlite_text_factory(dbapi_conn, connection_record):
                     # 将无效 UTF-8 字符替换为 �
+                    dbapi_conn.execute("PRAGMA journal_mode=WAL")
+                    dbapi_conn.execute("PRAGMA busy_timeout=10000")
+                    dbapi_conn.execute("PRAGMA synchronous=NORMAL")
                     dbapi_conn.text_factory = lambda x: x.decode('utf-8', errors='replace')
             
             self.session_factory=self.get_session_factory()
@@ -229,7 +232,7 @@ class Db:
         session = None
         try:
             session = self.get_session()
-            return session.query(Feed).filter(Feed.status == 1).all()
+            return session.query(Feed).filter(Feed.status == 1, Feed.faker_id != "MP_WXS_FEATURED_ARTICLES").all()
         except Exception as e:
             print(f"Failed to fetch Feed: {e}")
             return e # type: ignore

--- a/core/db.py
+++ b/core/db.py
@@ -94,6 +94,9 @@ class Db:
             if "has_content" not in columns:
                 alter_statements.append("ALTER TABLE articles ADD COLUMN has_content INTEGER DEFAULT 0")
 
+            if "fetch_started_at" not in columns:
+                alter_statements.append("ALTER TABLE articles ADD COLUMN fetch_started_at BIGINT")
+
             if not alter_statements:
                 return
 

--- a/core/export_job.py
+++ b/core/export_job.py
@@ -1,0 +1,151 @@
+"""
+文章导出后台任务管理。
+
+与 core/switch_job.py 同形，独立是为了语义清晰（导出任务的字段
+与切换账号不同：total_records / processed_records / skipped_records /
+output_path 等）。
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# 全局单例
+_MANAGER: Optional["ExportJobManager"] = None
+_LOCK = threading.Lock()
+
+
+def get_export_job_manager() -> "ExportJobManager":
+    """进程内唯一 ExportJobManager 实例。"""
+    global _MANAGER
+    if _MANAGER is None:
+        with _LOCK:
+            if _MANAGER is None:
+                _MANAGER = ExportJobManager()
+    return _MANAGER
+
+
+@dataclass
+class ExportJob:
+    job_id: str
+    user_id: str
+    mp_id: str
+    fmt_summary: str  # e.g. "pdf+md+json"
+    started_at: float = field(default_factory=time.time)
+    finished_at: Optional[float] = None
+    stage: str = "queued"  # queued / counting / rendering_pdfs / converting_docx / writing_files / packaging / done / failed
+    message: str = "任务已入队"
+    progress: int = 0  # 0..100
+    ok: Optional[bool] = None
+    total_records: int = 0
+    processed_records: int = 0
+    skipped_records: int = 0
+    output_path: Optional[str] = None
+    listeners: List[asyncio.Queue] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "stage": self.stage,
+            "message": self.message,
+            "progress": self.progress,
+            "ok": self.ok,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "total_records": self.total_records,
+            "processed_records": self.processed_records,
+            "skipped_records": self.skipped_records,
+            "output_path": self.output_path,
+            "mp_id": self.mp_id,
+            "fmt_summary": self.fmt_summary,
+        }
+
+    def push_event(self) -> None:
+        snapshot = self.to_dict()
+        for q in self.listeners:
+            try:
+                q.put_nowait(snapshot)
+            except asyncio.QueueFull:
+                # 订阅者消费太慢；记录一次以便排查，但不要阻塞生产者
+                import logging
+                logging.getLogger(__name__).warning(
+                    "ExportJob SSE listener queue full; dropping snapshot for job_id=%s", self.job_id
+                )
+
+
+class ExportJobManager:
+    def __init__(self) -> None:
+        self._jobs: Dict[str, ExportJob] = {}
+        self._lock = threading.Lock()
+
+    def create_job(self, user_id: str, mp_id: str, fmt_summary: str) -> ExportJob:
+        job_id = uuid.uuid4().hex[:12]
+        job = ExportJob(job_id=job_id, user_id=user_id, mp_id=mp_id, fmt_summary=fmt_summary)
+        with self._lock:
+            self._jobs[job_id] = job
+            # 限制保留数量
+            if len(self._jobs) > 32:
+                finished = sorted(
+                    (j for j in self._jobs.values() if j.finished_at is not None),
+                    key=lambda j: j.finished_at or 0,
+                )
+                for old in finished[: len(self._jobs) - 32]:
+                    self._jobs.pop(old.job_id, None)
+        return job
+
+    def get_job(self, job_id: str) -> Optional[ExportJob]:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    # 仅允许通过 update() 更新的字段；其他内部字段（如 listeners）不可外部写入
+    _UPDATABLE = frozenset({
+        "stage", "message", "progress", "ok", "finished_at",
+        "total_records", "processed_records", "skipped_records", "output_path",
+    })
+
+    def update(self, job_id: str, **kwargs: Any) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            for key, value in kwargs.items():
+                if key in self._UPDATABLE:
+                    setattr(job, key, value)
+            job.push_event()
+
+    def finish(self, job_id: str, ok: bool, message: str, output_path: Optional[str] = None) -> None:
+        kw: Dict[str, Any] = dict(
+            finished_at=time.time(),
+            ok=ok,
+            stage="done" if ok else "failed",
+            progress=100,
+            message=message,
+        )
+        if output_path is not None:
+            kw["output_path"] = output_path
+        self.update(job_id, **kw)
+
+    async def subscribe(self, job_id: str) -> asyncio.Queue:
+        job = self.get_job(job_id)
+        if job is None:
+            raise KeyError(job_id)
+        q: asyncio.Queue = asyncio.Queue(maxsize=64)
+        with self._lock:
+            job.listeners.append(q)
+            snap = job.to_dict()
+        await q.put(snap)
+        return q
+
+    def unsubscribe(self, job_id: str, q: asyncio.Queue) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            try:
+                job.listeners.remove(q)
+            except ValueError:
+                pass

--- a/core/exporter.py
+++ b/core/exporter.py
@@ -1,0 +1,326 @@
+"""
+优化版批量文章导出。
+
+修复原 apis/tools.py:_export_articles_worker 的几个性能问题：
+1. 每篇文章都重启 Playwright 浏览器（耗时大头：~5-10s × N）。
+2. 默认强制 chromium，绕过 BROWSER_TYPE=webkit 设置。
+3. 同步串行处理且无任何进度上报。
+4. 没有跳过无效文章（无 URL / 无 content），仍尝试渲染。
+
+新实现：
+* 复用单个 WebToPDFConverter 跨整批文章。
+* 浏览器类型由 BROWSER_TYPE 环境变量或 config 决定，默认 webkit。
+* 通过 progress_callback(stage, message, progress, **kw) 实时报告进度。
+* 跳过无 URL / 无 content 的文章，但仍然将其计入"skipped"。
+"""
+from __future__ import annotations
+
+import os
+import sys
+import asyncio
+import json
+import zipfile
+import csv
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+from core.common.file_tools import sanitize_filename
+from core.print import print_success, print_error, print_warning
+
+
+ProgressCallback = Optional[Callable[..., None]]
+
+
+def _report(cb: ProgressCallback, stage: str, message: str, progress: int = 0, **kw: Any) -> None:
+    if cb is None:
+        return
+    try:
+        cb(stage=stage, message=message, progress=progress, **kw)
+    except Exception:
+        pass
+
+
+def _normalize_browser_type() -> str:
+    """选择 PDF 渲染浏览器：BROWSER_TYPE 环境变量 > 已安装的浏览器 > config。
+
+    由于实际部署中 firefox / chromium / msedge 不一定都通过
+    `playwright install` 安装过，这里探测 playwright 的浏览器缓存目录，
+    优先选已安装的（webkit 总是优先 — 与上游保持一致）。
+    """
+    forced = os.environ.get("BROWSER_TYPE", "").strip().lower()
+    if forced in ("webkit", "chromium", "firefox", "msedge"):
+        return forced
+
+    # 探测 playwright 缓存目录
+    candidates = ["webkit", "chromium", "firefox", "msedge"]
+    try:
+        from pathlib import Path
+        cache = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData/Local"))) / "ms-playwright"
+        for c in candidates:
+            if list(cache.glob(f"{c}-*")):
+                return c
+    except Exception:
+        pass
+
+    try:
+        from core.config import cfg
+        bt = cfg.get("gather.browser_type", "webkit")
+        return str(bt or "webkit")
+    except Exception:
+        return "webkit"
+
+
+async def _render_pdfs_in_batch(
+    items: list[tuple[Any, str]],
+    browser_type: str,
+) -> dict[str, str]:
+    """复用同一个浏览器，把 (article, target_pdf_path) 列表全部渲染。
+
+    Returns: 映射 article.id -> 已生成的 PDF 路径（成功的）。
+    """
+    if not items:
+        return {}
+    from tools.mdtools.pdf import WebToPDFConverter
+
+    results: dict[str, str] = {}
+    async with WebToPDFConverter(
+        headless=True,
+        browser_type=browser_type,
+        timeout=30000,
+        wait_time=1500,
+    ) as converter:
+        for article, pdf_path in items:
+            try:
+                port = "8001"
+                try:
+                    from core.config import cfg
+                    port = str(cfg.get("port", "8001"))
+                except Exception:
+                    pass
+                url = (
+                    article.url
+                    if not (hasattr(article, "content") and (article.content or ""))
+                    else f"http://127.0.0.1:{port}/views/print/{article.id}"
+                )
+                ok = await converter.convert_url_to_pdf(
+                    url=url,
+                    output_path=pdf_path,
+                )
+                if ok and os.path.exists(pdf_path):
+                    results[article.id] = pdf_path
+            except Exception as e:
+                print_warning(f"渲染 PDF 失败 {article.id}: {e}")
+    return results
+
+
+def _export_articles_optimized(
+    *,
+    session,
+    mp_id: str,
+    doc_id: Optional[list],
+    page_size: int,
+    page_count: int,
+    add_title: bool,
+    remove_images: bool,
+    remove_links: bool,
+    export_md: bool,
+    export_docx: bool,
+    export_json: bool,
+    export_csv: bool,
+    export_pdf: bool,
+    docx_path: str,
+    progress_callback: ProgressCallback = None,
+) -> dict[str, int]:
+    """同步包装的批量导出，返回 {total, processed, skipped}。"""
+    return asyncio.run(
+        _export_articles_async(
+            session=session,
+            mp_id=mp_id,
+            doc_id=doc_id,
+            page_size=page_size,
+            page_count=page_count,
+            add_title=add_title,
+            remove_images=remove_images,
+            remove_links=remove_links,
+            export_md=export_md,
+            export_docx=export_docx,
+            export_json=export_json,
+            export_csv=export_csv,
+            export_pdf=export_pdf,
+            docx_path=docx_path,
+            progress_callback=progress_callback,
+        )
+    )
+
+
+async def _export_articles_async(
+    *,
+    session,
+    mp_id: str,
+    doc_id: Optional[list],
+    page_size: int,
+    page_count: int,
+    add_title: bool,
+    remove_images: bool,
+    remove_links: bool,
+    export_md: bool,
+    export_json: bool,
+    export_csv: bool,
+    export_pdf: bool,
+    export_docx: bool,
+    docx_path: str,
+    progress_callback: ProgressCallback = None,
+) -> dict[str, int]:
+    """异步批量导出。"""
+    from core.models import Article
+
+    # 1. 计数
+    _report(progress_callback, "counting", "正在统计文章数…", 0)
+    base_q = session.query(Article).filter(
+        Article.content != None,  # noqa: E711
+        Article.status == 1,
+    )
+    if mp_id:
+        base_q = base_q.where(Article.mp_id.in_(mp_id.split(",")))
+    if doc_id:
+        base_q = base_q.where(Article.id.in_(doc_id))
+    base_q = base_q.order_by(Article.publish_time.desc(), Article.id.desc())
+
+    # 限制 page_count（0 表示全部）
+    if page_count and page_count > 0:
+        base_q = base_q.limit(page_size * page_count)
+
+    all_articles = base_q.all()
+    total = len(all_articles)
+    _report(
+        progress_callback, "counting",
+        f"找到 {total} 篇文章", 5,
+        total_records=total,
+    )
+
+    if total == 0:
+        return {"total": 0, "processed": 0, "skipped": 0}
+
+    # 2. 跳过无效
+    valid_articles = []
+    skipped = 0
+    for art in all_articles:
+        if not (hasattr(art, "content") and (art.content or "")):
+            skipped += 1
+            continue
+        if not (art.url or ""):
+            skipped += 1
+            continue
+        valid_articles.append(art)
+
+    _report(
+        progress_callback, "preparing",
+        f"将处理 {len(valid_articles)} 篇，跳过 {skipped} 篇", 10,
+        skipped_records=skipped,
+    )
+
+    # 3. 准备输出目录、文件名
+    os.makedirs(docx_path, exist_ok=True)
+    article_paths = []
+    for art in valid_articles:
+        name = (
+            datetime.fromtimestamp(art.publish_time, tz=timezone.utc).strftime("%Y%m%d")
+            + "_" + art.title
+        )
+        safe = sanitize_filename(name)
+        article_paths.append((art, safe))
+
+    # 4. 渲染 PDF（如果需要）—— 复用单个浏览器
+    pdf_paths: dict[str, str] = {}
+    if export_pdf or export_docx:
+        browser_type = _normalize_browser_type()
+        _report(
+            progress_callback, "rendering_pdfs",
+            f"使用 {browser_type} 浏览器渲染 {len(valid_articles)} 个 PDF…", 15,
+        )
+        items = [(art, os.path.join(docx_path, f"{safe}.pdf")) for art, safe in article_paths]
+        pdf_paths = await _render_pdfs_in_batch(items, browser_type)
+        print_success(f"PDF 渲染完成：{len(pdf_paths)}/{len(items)}")
+
+    # 5. 其它格式（MD/JSON/CSV 全部同步处理 + DOCX 转换）
+    processed = 0
+    csv_file = None
+    csv_writer = None
+    if export_csv:
+        csv_file = open(os.path.join(docx_path, "articles.csv"), "w", newline="", encoding="utf-8")
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(["标题", "链接", "发布时间"])
+
+    try:
+        for idx, (art, safe) in enumerate(article_paths):
+            base_progress = 30 + int(60 * idx / max(1, len(article_paths)))
+            _report(
+                progress_callback, "writing_files",
+                f"处理 {idx + 1}/{len(article_paths)}: {art.title[:30]}", base_progress,
+                processed_records=processed,
+            )
+
+            # Markdown
+            if export_md and art.content:
+                try:
+                    from tools.mdtools.html2doc import html_to_markdown_file
+                    md_path = os.path.join(docx_path, f"{safe}.md")
+                    cfg_local = {
+                        "remove_images": remove_images,
+                        "remove_links": remove_links,
+                    }
+                    document_title = art.title if add_title else None
+                    html_to_markdown_file(art.content, md_path, document_title, cfg_local)
+                except Exception as e:
+                    print_warning(f"Markdown 失败 {art.id}: {e}")
+
+            # DOCX（PDF -> DOCX）
+            if export_docx and art.id in pdf_paths:
+                try:
+                    from tools.mdtools.pdf_extractor import pdf_to_docx
+                    pdf_path = pdf_paths[art.id]
+                    docx_path_full = os.path.join(docx_path, f"{safe}.docx")
+                    pdf_to_docx(pdf_path, docx_path_full)
+                except Exception as e:
+                    print_warning(f"DOCX 失败 {art.id}: {e}")
+
+            # JSON
+            if export_json:
+                try:
+                    json_path = os.path.join(docx_path, f"{safe}.json")
+                    with open(json_path, "w", encoding="utf-8") as f:
+                        json.dump({
+                            "id": art.id,
+                            "url": art.url,
+                            "title": art.title,
+                            "pic_url": art.pic_url,
+                            "description": art.description,
+                            "status": art.status,
+                            "publish_time": art.publish_time,
+                        }, f, ensure_ascii=False, indent=2)
+                except Exception as e:
+                    print_warning(f"JSON 失败 {art.id}: {e}")
+
+            # CSV
+            if export_csv and csv_writer:
+                try:
+                    csv_writer.writerow([
+                        art.title,
+                        art.url,
+                        datetime.fromtimestamp(art.publish_time, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+                    ])
+                except Exception as e:
+                    print_warning(f"CSV 失败 {art.id}: {e}")
+
+            processed += 1
+
+    finally:
+        if csv_file:
+            csv_file.close()
+
+    return {
+        "total": total,
+        "processed": processed,
+        "skipped": skipped,
+        "pdf_rendered": len(pdf_paths),
+    }

--- a/core/models/article.py
+++ b/core/models/article.py
@@ -40,6 +40,7 @@ class ArticleBase(Base):
     is_favorite = Column(Integer, default=0)  # 是否收藏
     fix_fail_count = Column(Integer, default=0)  # 修正内容失败次数
     has_content = Column(Integer, default=0, index=True)  # 是否有正文内容（0=无，1=有），用于加速查询
+    fetch_started_at = Column(BigInteger)  # 正文抓取认领时间（Unix毫秒），用于恢复陈旧锁
 class Article(ArticleBase):
     content = Column(Text)
     content_html = Column(Text)
@@ -82,5 +83,6 @@ class Article(ArticleBase):
             'is_read': self.is_read,
             'is_favorite': self.is_favorite,
             'fix_fail_count': self.fix_fail_count,
-            'has_content': self.has_content
+            'has_content': self.has_content,
+            'fetch_started_at': self.fetch_started_at
         }

--- a/core/notice/custom.py
+++ b/core/notice/custom.py
@@ -20,7 +20,8 @@ def send_custom_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/dingtalk.py
+++ b/core/notice/dingtalk.py
@@ -27,7 +27,8 @@ def send_dingtalk_message(webhook_url, title, text, is_at_all=False, at_mobiles=
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/feishu.py
+++ b/core/notice/feishu.py
@@ -40,7 +40,8 @@ def send_feishu_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/notice/wechat.py
+++ b/core/notice/wechat.py
@@ -24,7 +24,8 @@ def send_wechat_message(webhook_url, title, text):
         response = requests.post(
             url=webhook_url,
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            timeout=30
         )
         print(response.text)
     except Exception as e:

--- a/core/process_timeout.py
+++ b/core/process_timeout.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+import signal
+from collections.abc import Callable
+from typing import Any
+
+
+class ProcessExecutionError(RuntimeError):
+    pass
+
+
+class ProcessExecutionTimeout(TimeoutError):
+    pass
+
+
+def _process_entry(connection, target: Callable, args: tuple, kwargs: dict) -> None:
+    if os.name == "posix":
+        os.setsid()
+
+    try:
+        connection.send(("ok", target(*args, **kwargs)))
+    except BaseException as exc:
+        connection.send(("error", f"{type(exc).__name__}: {exc}"))
+    finally:
+        connection.close()
+
+
+def _terminate_process_tree(process, cleanup_timeout: float) -> None:
+    if not process.is_alive():
+        process.join(timeout=cleanup_timeout)
+        return
+
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            if process.is_alive():
+                process.terminate()
+    else:
+        process.terminate()
+
+    process.join(timeout=cleanup_timeout)
+    if not process.is_alive():
+        return
+
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            if process.is_alive():
+                process.kill()
+    else:
+        process.kill()
+    process.join(timeout=cleanup_timeout)
+
+
+def run_in_process(
+    target: Callable,
+    *args: Any,
+    timeout: float,
+    cleanup_timeout: float = 5.0,
+    **kwargs: Any,
+) -> Any:
+    """Run a callable with a wall-clock timeout that can kill child processes."""
+    context = multiprocessing.get_context("spawn")
+    receive_connection, send_connection = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_process_entry,
+        args=(send_connection, target, args, kwargs),
+    )
+    process.start()
+    send_connection.close()
+
+    try:
+        if not receive_connection.poll(timeout):
+            _terminate_process_tree(process, cleanup_timeout)
+            raise ProcessExecutionTimeout(
+                f"process exceeded wall-clock timeout of {timeout:.1f}s"
+            )
+
+        try:
+            status, payload = receive_connection.recv()
+        except EOFError as exc:
+            raise ProcessExecutionError(
+                f"process exited without a result (exit code {process.exitcode})"
+            ) from exc
+
+        process.join(timeout=cleanup_timeout)
+        if process.is_alive():
+            _terminate_process_tree(process, cleanup_timeout)
+
+        if status == "error":
+            raise ProcessExecutionError(payload)
+        return payload
+    finally:
+        receive_connection.close()
+        if process.is_alive():
+            _terminate_process_tree(process, cleanup_timeout)

--- a/core/queue/queue.py
+++ b/core/queue/queue.py
@@ -368,9 +368,16 @@ class TaskQueueManager:
                 max_retries=max_retries
             ))
             
-            # 保存到 Redis
-            self._save_pending_to_redis()
-            self._save_status_to_redis()
+            # 优化：只追加新任务到 Redis，而不是全量重写
+            redis_client = _get_redis()
+            if redis_client:
+                try:
+                    new_item = self._pending_items[-1].to_dict()
+                    redis_client.rpush(self._redis_keys['pending'], json.dumps(new_item, ensure_ascii=False))
+                    # 只更新计数，不保存完整状态
+                    redis_client.hincrby(self._redis_keys['status'], 'pending_count', 1)
+                except Exception as e:
+                    print_error(f"追加任务到 Redis 失败: {e}")
             
             # 标记需要广播，但不在这里执行（避免在锁内进行异步操作）
             broadcast_needed = True

--- a/core/queue/queue.py
+++ b/core/queue/queue.py
@@ -6,6 +6,7 @@ import json
 from typing import Callable, Any, Optional
 from datetime import datetime
 from dataclasses import dataclass, field, asdict
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from core.print import print_error, print_info, print_warning, print_success
 
 # Redis 键前缀 - 主队列（文章列表采集）
@@ -457,7 +458,15 @@ class TaskQueueManager:
                         try:
                             # 记录任务开始时间
                             start_time = time.time()
-                            task(*args, **kwargs)
+                            task_executor = ThreadPoolExecutor(max_workers=1)
+                            try:
+                                future = task_executor.submit(task, *args, **kwargs)
+                                future.result(timeout=600)
+                            except FutureTimeoutError:
+                                print_error("Task [{}] execution timeout (10 min)".format(task_name))
+                                raise Exception("Task timed out after 600s")
+                            finally:
+                                task_executor.shutdown(wait=False)
                             # 记录任务执行时间
                             duration = time.time() - start_time
                             

--- a/core/switch_job.py
+++ b/core/switch_job.py
@@ -1,0 +1,143 @@
+"""
+切换公众号账号后台任务管理。
+
+职责：
+1. 接收前端触发，立即返回 job_id（避免阻塞 HTTP 请求）。
+2. 在后台线程跑实际的 Playwright 切换流程。
+3. 维护每个 job 的状态（stage / message / finished / ok）。
+4. 通过 asyncio.Queue 在 SSE 端点上广播进度事件。
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# 全局单例
+_MANAGER: Optional["SwitchJobManager"] = None
+_LOCK = threading.Lock()
+
+
+def get_manager() -> "SwitchJobManager":
+    """进程内唯一 SwitchJobManager 实例。"""
+    global _MANAGER
+    if _MANAGER is None:
+        with _LOCK:
+            if _MANAGER is None:
+                _MANAGER = SwitchJobManager()
+    return _MANAGER
+
+
+@dataclass
+class SwitchJob:
+    job_id: str
+    user_id: str
+    target_username: str = ""
+    started_at: float = field(default_factory=time.time)
+    finished_at: Optional[float] = None
+    stage: str = "queued"  # queued / stopping_queues / checking_token / starting_browser / clicking / done / failed
+    message: str = "任务已入队"
+    progress: int = 0  # 0..100
+    ok: Optional[bool] = None  # None 表示进行中
+    listeners: List[asyncio.Queue] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "stage": self.stage,
+            "message": self.message,
+            "progress": self.progress,
+            "ok": self.ok,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+        }
+
+    def push_event(self) -> None:
+        """向所有监听者推送当前快照。"""
+        snapshot = self.to_dict()
+        for q in self.listeners:
+            try:
+                q.put_nowait(snapshot)
+            except Exception:
+                pass
+
+
+class SwitchJobManager:
+    def __init__(self) -> None:
+        self._jobs: Dict[str, SwitchJob] = {}
+        self._lock = threading.Lock()
+
+    def create_job(self, user_id: str, target_username: str = "") -> SwitchJob:
+        job_id = uuid.uuid4().hex[:12]
+        job = SwitchJob(job_id=job_id, user_id=user_id, target_username=target_username)
+        with self._lock:
+            self._jobs[job_id] = job
+        # 旧的已完成 job 限制内存：保留最近 16 个
+        with self._lock:
+            if len(self._jobs) > 32:
+                # 移除最旧且已完成的
+                finished = sorted(
+                    (j for j in self._jobs.values() if j.finished_at is not None),
+                    key=lambda j: j.finished_at or 0,
+                )
+                for old in finished[: len(self._jobs) - 32]:
+                    self._jobs.pop(old.job_id, None)
+        return job
+
+    def get_job(self, job_id: str) -> Optional[SwitchJob]:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def list_jobs(self) -> List[SwitchJob]:
+        with self._lock:
+            return list(self._jobs.values())
+
+    def update(self, job_id: str, **kwargs: Any) -> None:
+        """原子更新 job 字段并向所有 SSE 监听者广播。"""
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            for key, value in kwargs.items():
+                if hasattr(job, key):
+                    setattr(job, key, value)
+            job.push_event()
+
+    def finish(self, job_id: str, ok: bool, message: str) -> None:
+        self.update(
+            job_id,
+            finished_at=time.time(),
+            ok=ok,
+            stage="done" if ok else "failed",
+            progress=100,
+            message=message,
+        )
+
+    async def subscribe(self, job_id: str) -> asyncio.Queue:
+        """注册 SSE 监听者，返回其专属队列。先收到一份快照。"""
+        job = self.get_job(job_id)
+        if job is None:
+            raise KeyError(job_id)
+        loop = asyncio.get_running_loop()
+        q: asyncio.Queue = asyncio.Queue(maxsize=64)
+        # 监听者需要锁保护 list
+        with self._lock:
+            job.listeners.append(q)
+            snap = job.to_dict()
+        # 先把当前状态推给订阅者
+        await q.put(snap)
+        return q
+
+    def unsubscribe(self, job_id: str, q: asyncio.Queue) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            try:
+                job.listeners.remove(q)
+            except ValueError:
+                pass

--- a/core/wx/base.py
+++ b/core/wx/base.py
@@ -320,11 +320,10 @@ class WxGather:
         if code=="Invalid Session":
             # from core.queue import TaskQueue
             # TaskQueue.clear_queue()  # 已注释：避免微信认证失效时清空队列
-            if cfg.get("server.send_code")=="True":
-                from jobs.failauth import send_wx_code
-                import threading
-                setStatus(False)
-                threading.Thread(target=send_wx_code,args=(f"公众号平台登录失效,请重新登录",)).start()
+            from jobs.failauth import send_wx_code
+            import threading
+            setStatus(False)
+            threading.Thread(target=send_wx_code,args=(f"公众号平台登录失效,请重新登录",)).start()
             # send_wx_code(f"公众号平台登录失效,请重新登录")
             raise Exception(error)
         # raise Exception(error)

--- a/core/wx/base.py
+++ b/core/wx/base.py
@@ -298,15 +298,21 @@ class WxGather:
                 return
             import time
             self.start_time = time.time()  # 记录开始执行时间
-            self.update_mps(
-                mp_id, #type: ingnore
-                            Feed( 
-            sync_time=int(time.time()),
-            update_time=int(time.time()),
-            ))
+            # Delay cursor advancement until the list request completes successfully.
         except Exception as e:
             print_error(f"开始采集失败: {e}")
 
+    def CommitSync(self, mp_id):
+        """"Advance the feed cursor only after a successful list crawl.""""
+        if not mp_id:
+            return
+        self.update_mps(
+            mp_id,
+            Feed(
+                sync_time=int(time.time()),
+                update_time=int(time.time()),
+            ),
+        )
     def Item_Over(self,item=None,CallBack=None):
         print(f"item end")
         _cookies=[{'name': c.name, 'value': c.value, 'domain': c.domain,'expiry':c.expires,'expires':c.expires} for c in self._cookies]

--- a/core/wx/model/api.py
+++ b/core/wx/model/api.py
@@ -21,8 +21,7 @@ class MpsApi(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page=0,MaxPage:int=1,interval=10,Gather_Content=True,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-             Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"API获取模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsg"

--- a/core/wx/model/api.py
+++ b/core/wx/model/api.py
@@ -98,5 +98,9 @@ class MpsApi(WxGather):
                 break
             finally:
                 super().Item_Over(item={"mps_id":Mps_id,"mps_title":Mps_title},CallBack=Item_Over_CallBack)
+        # Do not move the cursor if rate limiting, timeout, session failure, or
+        # another incomplete response stopped this crawl before all requested pages.
+        if i >= MaxPage:
+            super().CommitSync(Mps_id)
         super().Over(CallBack=Over_CallBack)
         pass

--- a/core/wx/model/app.py
+++ b/core/wx/model/app.py
@@ -26,8 +26,7 @@ class MpsAppMsg(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str=None,Mps_id:str=None,Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-            Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"APP浏览器模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsgpublish"

--- a/core/wx/model/app.py
+++ b/core/wx/model/app.py
@@ -108,5 +108,9 @@ class MpsAppMsg(WxGather):
                 break
             finally:
                 super().Item_Over(item={"mps_id":Mps_id,"mps_title":Mps_title},CallBack=Item_Over_CallBack)
+        # Do not move the cursor if rate limiting, timeout, session failure, or
+        # another incomplete response stopped this crawl before all requested pages.
+        if i >= MaxPage:
+            super().CommitSync(Mps_id)
         super().Over(CallBack=Over_CallBack)
         pass

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -57,7 +57,7 @@ class MpsWeb(WxGather):
             time.sleep(random.randint(0,interval))
             try:
                 headers = self.fix_header(url)
-                resp = session.get(url, headers=headers, params = params, verify=False)
+                resp = session.get(url, headers=headers, params = params, verify=False, timeout=(10, 30))
                 
                 msg = resp.json()
                 self._cookies =resp.cookies

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -26,8 +26,7 @@ class MpsWeb(WxGather):
     # 重写 get_Articles 方法
     def get_Articles(self, faker_id:str='',Mps_id:str='',Mps_title="",CallBack=None,start_page:int=0,MaxPage:int=1,interval=10,Gather_Content=False,Item_Over_CallBack=None,Over_CallBack=None):
         super().Start(mp_id=Mps_id)
-        if self.Gather_Content:
-            Gather_Content=True
+        Gather_Content = self.Gather_Content
         print(f"Web浏览器模式,是否采集[{Mps_title}]内容：{Gather_Content}\n")
         # 请求参数
         url = "https://mp.weixin.qq.com/cgi-bin/appmsgpublish"

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -69,6 +69,15 @@ class MpsWeb(WxGather):
                 if msg['base_resp']['ret'] == 200003:
                     super().Error("Invalid Session, stop at {}".format(str(begin)),code="Invalid Session")
                     break
+                # 处理200002错误：参数无效
+                if msg['base_resp']['ret'] == 200002:
+                    super().Error("Invalid arguments, stop at {}".format(str(begin)), code="Invalid Arguments")
+                    # 设置feed状态为0并继续下一个任务
+                    self._set_feed_status(Mps_id, 0)
+                    # 不break，而是return，这样可以继续下一个任务
+                    super().Item_Over(item={"mps_id":Mps_id,"mps_title":Mps_title},CallBack=Item_Over_CallBack)
+                    super().Over(CallBack=Over_CallBack)
+                    return
                 if msg['base_resp']['ret'] != 0:
                     super().Error("错误原因:{}:代码:{}".format(msg['base_resp']['err_msg'],msg['base_resp']['ret']),code=msg['base_resp']['err_msg'])
                     break    
@@ -112,3 +121,19 @@ class MpsWeb(WxGather):
                 super().Item_Over(item={"mps_id":Mps_id,"mps_title":Mps_title},CallBack=Item_Over_CallBack)
         super().Over(CallBack=Over_CallBack)
         pass
+    # 新增辅助方法用于设置feed状态
+    def _set_feed_status(self, feed_id: str, status: int):
+        """设置feed状态"""
+        try:
+            from core.db import DB
+            from core.models import Feed
+            session = DB.get_session()
+            feed = session.query(Feed).filter(Feed.id == feed_id).first()
+            if feed:
+                feed.status = status
+                session.commit()
+                print(f"已将feed {feed_id} 的状态设置为 {status}")
+            else:
+                print(f"未找到feed {feed_id}")
+        except Exception as e:
+            logger.error(f"设置feed状态失败: {e}")

--- a/core/wx/model/web.py
+++ b/core/wx/model/web.py
@@ -118,6 +118,10 @@ class MpsWeb(WxGather):
                 break
             finally:
                 super().Item_Over(item={"mps_id":Mps_id,"mps_title":Mps_title},CallBack=Item_Over_CallBack)
+        # Do not move the cursor if rate limiting, timeout, session failure, or
+        # another incomplete response stopped this crawl before all requested pages.
+        if i >= MaxPage:
+            super().CommitSync(Mps_id)
         super().Over(CallBack=Over_CallBack)
         pass
     # 新增辅助方法用于设置feed状态

--- a/driver/anti_crawler_config.py
+++ b/driver/anti_crawler_config.py
@@ -30,8 +30,7 @@ class AntiCrawlerConfig:
             "zh-CN,zh;q=0.9,en;q=0.8",
             "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2",
             "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7"
-        ],
-        'cache_control': ["no-cache", "max-age=0", "no-store"]
+        ]
     }
     
     # 时区配置
@@ -94,8 +93,11 @@ class AntiCrawlerConfig:
             "Accept": random.choice(self.HEADERS['accept']),
             "Accept-Language": random.choice(self.HEADERS['accept_language']),
             "Accept-Encoding": "gzip, deflate, br",
-            "Cache-Control": random.choice(self.HEADERS['cache_control']),
-            "Upgrade-Insecure-Requests": "1",
+            # 注意：不能设置 Cache-Control 和 Upgrade-Insecure-Requests。
+            # extra_http_headers 会作用于页面发出的所有请求（包括XHR），
+            # 而真实浏览器只在页面导航请求上带这两个头；
+            # 带上后 mp.weixin.qq.com 登录页初始化失败，
+            # #app 一直保持 visibility:hidden，登录二维码无法加载
             "Sec-Fetch-Dest": "document",
             "Sec-Fetch-Mode": "navigate",
             "Sec-Fetch-Site": "none",

--- a/driver/chrome_path.py
+++ b/driver/chrome_path.py
@@ -1,0 +1,52 @@
+"""
+跨平台解析本地 Chromium 内核浏览器（Chrome / Edge / Chromium）可执行文件路径。
+
+设计目标：
+- 不写死任何机器专属绝对路径（如某台 Windows 的 D:\\Tools\\...）。
+- 跨平台：Win11 / Docker-Linux / macOS 均可用。
+- 默认“不启用”：解析不到时返回 None，由调用方回退到 Playwright 自带浏览器，
+  从而保持上游默认行为（默认 webkit）完全不变，Docker/Linux 零回归。
+
+解析优先级：
+  1. 环境变量 CHROME_EXECUTABLE_PATH（跨平台、最高优先级，用户显式指定）
+  2. 当前操作系统的“标准安装位置”自动发现（仅当文件确实存在时才采用）
+  3. 都没有 -> 返回 None
+"""
+import os
+import sys
+
+# 仅收录各平台“标准”安装位置；不含任何机器专属路径。
+# 找不到时列表自然跳过，返回 None（调用方回退自带浏览器）。
+_CANDIDATES = {
+    "win32": [
+        os.path.expandvars(r"%ProgramFiles%\Google\Chrome\Application\chrome.exe"),
+        os.path.expandvars(r"%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe"),
+        os.path.expandvars(r"%ProgramFiles%\Microsoft\Edge\Application\msedge.exe"),
+        os.path.expandvars(r"%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe"),
+    ],
+    "linux": [
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+        "/usr/bin/chromium",
+        "/usr/bin/chromium-browser",
+    ],
+    "darwin": [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    ],
+}
+
+
+def get_chrome_executable_path() -> "str | None":
+    """返回可用的 Chromium 内核浏览器可执行文件路径；无则返回 None。
+
+    返回 None 时，调用方应保持原有浏览器类型（如上游默认的 webkit），
+    由 Playwright 启动其自带浏览器，确保 Docker/Linux 默认行为不变。
+    """
+    env = os.environ.get("CHROME_EXECUTABLE_PATH")
+    if env and os.path.exists(env):
+        return env
+    for cand in _CANDIDATES.get(sys.platform, []):
+        if cand and os.path.exists(cand):
+            return cand
+    return None

--- a/driver/playwright_driver.py
+++ b/driver/playwright_driver.py
@@ -18,6 +18,7 @@ if sys.platform == 'win32':
 
 from core.print import print_error, print_info, print_warning
 from driver.anti_crawler_config import AntiCrawlerConfig
+from driver.chrome_path import get_chrome_executable_path
 
 @dataclass
 class Metrics:
@@ -54,7 +55,8 @@ class PlaywrightController:
                  proxy_url: Optional[str] = "",
                  user_agent: Optional[str] = None,
                  debug: bool = False,
-                 mobile_mode: bool = False):
+                 mobile_mode: bool = False,
+                 apply_anti_crawler: bool = True):
         """
         初始化异步控制器
 
@@ -72,6 +74,11 @@ class PlaywrightController:
         self.proxy_url = proxy_url
         self.debug = debug
         self.mobile_mode = mobile_mode
+        # 是否应用反爬虫注入（extra_http_headers + 反检测脚本）。
+        # 反爬头含 Cache-Control / Sec-Fetch-* 等非 CORS 安全头，会触发跨域预检，
+        # 导致部分站点（如微信公众平台登录页）自身 JS 资源加载失败、二维码无法渲染。
+        # 微信登录等场景需退化为普通浏览器，故提供关闭开关。
+        self.apply_anti_crawler = apply_anti_crawler
 
         # 反爬虫配置实例
         self.anti_crawler_config = AntiCrawlerConfig()
@@ -119,6 +126,15 @@ class PlaywrightController:
             # 启动 Playwright
             self._playwright = await async_playwright().start()
 
+            # ===== 本地 Chrome 支持（可选，避免强制 playwright install 下载浏览器）=====
+            # 仅当通过环境变量 CHROME_EXECUTABLE_PATH 显式指定（或自动发现到本机标准安装的
+            # Chromium 内核浏览器）时才启用；否则保持上游默认浏览器（默认 webkit，由 Playwright 自带），
+            # 跨平台可移植，Docker/Linux 默认行为不受影响。
+            CHROME_PATH = get_chrome_executable_path()
+            if CHROME_PATH:
+                self.browser_type = "chromium"
+                print_info(f"使用本地 Chrome: {CHROME_PATH}（跳过 Playwright 浏览器下载）")
+
             # 选择浏览器类型
             browser_launcher = getattr(self._playwright, self.browser_type)
 
@@ -138,6 +154,9 @@ class PlaywrightController:
                     "--disable-dev-shm-usage",
                     "--no-sandbox",
                 ]
+                # 使用本地 Chrome 可执行文件，避免下载 Playwright 浏览器
+                if CHROME_PATH:
+                    launch_options["executable_path"] = CHROME_PATH
 
             # 添加代理
             if self.proxy_url:
@@ -157,8 +176,8 @@ class PlaywrightController:
                 "timezone_id": "Asia/Shanghai",
             }
 
-            # 应用额外的HTTP头
-            if "extra_http_headers" in anti_config:
+            # 应用额外的HTTP头（反爬注入可能破坏跨域资源加载，关闭时跳过）
+            if self.apply_anti_crawler and "extra_http_headers" in anti_config:
                 context_options["extra_http_headers"] = anti_config["extra_http_headers"]
 
             # 应用其他可选配置
@@ -171,8 +190,9 @@ class PlaywrightController:
             # 创建页面
             self._page = await self._context.new_page()
 
-            # ========== 核心改造：注入反检测脚本 ==========
-            await self._apply_anti_crawler_scripts(self._page)
+            # ========== 核心改造：注入反检测脚本（关闭反爬时跳过）==========
+            if self.apply_anti_crawler:
+                await self._apply_anti_crawler_scripts(self._page)
 
             # 记录启动时间
             self.metrics.browser_startup_time = time.time() - start_time

--- a/driver/playwright_driver.py
+++ b/driver/playwright_driver.py
@@ -130,10 +130,18 @@ class PlaywrightController:
             # 仅当通过环境变量 CHROME_EXECUTABLE_PATH 显式指定（或自动发现到本机标准安装的
             # Chromium 内核浏览器）时才启用；否则保持上游默认浏览器（默认 webkit，由 Playwright 自带），
             # 跨平台可移植，Docker/Linux 默认行为不受影响。
-            CHROME_PATH = get_chrome_executable_path()
-            if CHROME_PATH:
-                self.browser_type = "chromium"
-                print_info(f"使用本地 Chrome: {CHROME_PATH}（跳过 Playwright 浏览器下载）")
+            # 补丁：支持 BROWSER_TYPE 环境变量，用户可强制指定 webkit/chromium/firefox，
+            # 微信公众平台在 Windows 本地 Chrome 下经常触发反爬（QR 加载超时），
+            # 此时设置 BROWSER_TYPE=webkit 可绕过。
+            _forced_browser = os.environ.get("BROWSER_TYPE", "").strip().lower()
+            if _forced_browser in ("webkit", "chromium", "firefox", "msedge"):
+                self.browser_type = _forced_browser
+                print_info(f"通过 BROWSER_TYPE 强制使用浏览器: {self.browser_type}")
+            else:
+                CHROME_PATH = get_chrome_executable_path()
+                if CHROME_PATH:
+                    self.browser_type = "chromium"
+                    print_info(f"使用本地 Chrome: {CHROME_PATH}（跳过 Playwright 浏览器下载）")
 
             # 选择浏览器类型
             browser_launcher = getattr(self._playwright, self.browser_type)

--- a/driver/wx.py
+++ b/driver/wx.py
@@ -436,6 +436,38 @@ class Wx:
                 except Exception as e:
                     print(f"二维码图片获取失败: {str(e)}")
         return self.isLock
+    async def _wait_qrcode_ready(self, page, qr_tag, timeout=30):
+        """等待登录二维码图片加载完成（异步）
+
+        新版登录页可能默认展示"微信快捷登录"（open.weixin.qq.com iframe），
+        此时经典二维码处于隐藏状态且src为空，直接截图会得到空白图片或超时。
+        检测到该情况时点击"扫码登录"链接切换回二维码登录，
+        再等待二维码图片可见且真正加载完成。
+        """
+        import asyncio
+
+        deadline = time.time() + timeout
+        switch_clicked = False
+        while time.time() < deadline:
+            ready = await page.evaluate(
+                """(sel) => {
+                    const img = document.querySelector(sel);
+                    if (!img) return false;
+                    const style = window.getComputedStyle(img);
+                    if (style.display === 'none' || style.visibility === 'hidden') return false;
+                    return !!img.src && img.complete && img.naturalWidth > 50;
+                }""", qr_tag)
+            if ready:
+                return True
+            if not switch_clicked:
+                switch_link = page.locator("a.login__type__container__link_text", has_text="扫码登录")
+                if await switch_link.count() > 0 and await switch_link.first.is_visible():
+                    print_info("检测到快捷登录页面，切换到扫码登录...")
+                    await switch_link.first.click()
+                    switch_clicked = True
+            await asyncio.sleep(0.5)
+        return False
+
     async def wxLogin(self, CallBack=None, NeedExit=True):
         """
         微信公众平台登录流程（异步）：
@@ -474,11 +506,20 @@ class Wx:
             page = driver.page
 
             # 等待页面完全加载
+            # 新版登录页存在持续的轮询请求，networkidle可能永远不触发，
+            # 超时不视为错误，由后续二维码加载检测兜底
             print_info("正在加载登录页面...")
-            await page.wait_for_load_state("networkidle")
+            try:
+                await page.wait_for_load_state("networkidle", timeout=10000)
+            except Exception:
+                pass
 
             # 定位二维码区域
             qr_tag = ".login__type__container__scan__qrcode"
+            # 新版登录页可能默认展示"微信快捷登录"，二维码被隐藏或src为空，
+            # 需要先切换回扫码登录并等待二维码图片真正加载完成
+            if not await self._wait_qrcode_ready(page, qr_tag):
+                raise Exception("二维码加载超时，请重试")
             # 获取二维码图片URL
             qrcode = await page.query_selector(qr_tag)
             code_src = await qrcode.get_attribute("src")
@@ -503,7 +544,10 @@ class Wx:
                 if self.WX_HOME in current_url:
                     print(f"登录成功，正在获取cookie和token...")
             page.on('framenavigated', handle_frame_navigated)
-            await page.wait_for_event("framenavigated", timeout=5*60 * 1000)
+            # 只等待主页面跳转到公众平台首页，
+            # 不能用 wait_for_event("framenavigated")：页面内的快捷登录iframe
+            # 加载时也会触发该事件，导致未扫码就误判为登录成功
+            await page.wait_for_url(lambda url: "cgi-bin/home" in url, timeout=5*60 * 1000)
 
             from .success import setStatus
             with self._login_lock:

--- a/driver/wx.py
+++ b/driver/wx.py
@@ -82,14 +82,25 @@ class Wx:
         except Exception as e:
             print(f"提取token时出错: {str(e)}")
             return ''
-    async def switch_account(self, username: str = ""):
+    async def switch_account(self, username: str = "", progress_callback=None):
         """切换账号功能（异步）
+
         Args:
             username: 目标账号的用户名，如果为空则切换到其他可用账号
+            progress_callback: 可选回调，签名 ``callback(stage: str, message: str, progress: int) -> None``，
+                用于将进度广播到前端（SSE / 轮询）。
         """
         import asyncio
 
+        def report(stage: str, message: str, progress: int = 0) -> None:
+            if progress_callback is not None:
+                try:
+                    progress_callback(stage, message, progress)
+                except Exception:
+                    pass
+
         print("开始切换账号...")
+        report("queued", "任务开始", 0)
         main_queue_was_running = False
         content_queue_was_running = False
 
@@ -99,6 +110,7 @@ class Wx:
             main_queue_was_running = TaskQueue._is_running
             content_queue_was_running = ContentTaskQueue._is_running
 
+            report("stopping_queues", "暂停抓取队列", 5)
             # 停止队列
             if main_queue_was_running:
                 print_info("暂停主任务队列...")
@@ -107,8 +119,12 @@ class Wx:
                 print_info("暂停内容任务队列...")
                 ContentTaskQueue.stop()
 
-            # 等待当前任务真正完成
-            max_wait = 120  # 最大等待120秒
+            # 等待当前任务真正完成 — 通过配置可缩短；默认仍 120s 以保证抓取原子性
+            import os
+            try:
+                max_wait = int(os.getenv("SWITCH_MAX_WAIT", "120"))
+            except Exception:
+                max_wait = 120
             wait_interval = 1
             waited = 0
 
@@ -129,44 +145,63 @@ class Wx:
                     print_success("所有任务已完成，可以安全切换账号")
                     break
 
+                if waited % 5 == 0 and waited > 0:
+                    report("stopping_queues", f"等待任务完成中（{waited}/{max_wait}s）", 5 + min(20, waited // 6))
                 await asyncio.sleep(wait_interval)
                 waited += wait_interval
-                if waited % 5 == 0:
-                    print_info(f"等待任务完成中... ({waited}秒)")
 
             if waited >= max_wait:
                 print_warning("等待超时，仍有任务未完成，切换账号可能导致会话失效")
+                report("stopping_queues", f"队列等待超时，继续尝试（{waited}s）", 25)
 
+            report("checking_token", "检查 Token 有效性", 30)
             await self.Token(isClose=False)
             if getStatus() is False:
-                await self.Close()
+                # 提前暴露结果，不阻塞 60s；让前端用 UI 引导用户重新扫码
+                print_warning("Token 已过期，请重新扫码登录")
                 from jobs.failauth import send_wx_code
                 send_wx_code("账号过期，请重新扫码登录")
-                await asyncio.sleep(60)
+                report("failed", "Token 已过期，请调用 /auth/wechat/unbind 后重新扫码", 100)
                 return False
             await asyncio.sleep(1)
 
-            # 检查 controller 和 Page 对象是否有效
+            # 检查 controller 和 Page 对象是否有效；若不存在则回退到重新启动浏览器
             if not hasattr(self, 'controller') or self.controller is None:
-                print_error("Controller 未初始化，无法切换账号")
-                return False
+                print_warning("Controller 未初始化，正在重新创建浏览器...")
+                self.controller = PlaywrightController()
 
-            if not self.controller.is_page_valid():
-                print_error("Page 对象无效，无法切换账号")
-                return False
+            if not self.controller.is_page_valid() or self.controller.page is None:
+                report("starting_browser", "浏览器 Page 无效，正在重新打开公众平台…", 40)
+                print_warning("Page 对象无效或为 None，正在重新打开浏览器并导航到公众平台...")
+                try:
+                    await self.controller.start_browser()
+                    await self.controller.open_url(self.WX_LOGIN)
+                    # 网络空闲等待超时后继续；后续点击操作再处理是否需要登录
+                    try:
+                        await self.controller.page.wait_for_load_state("networkidle", timeout=10000)
+                    except Exception:
+                        pass
+                    await asyncio.sleep(2)
+                except Exception as e:
+                    print_error(f"重新打开浏览器失败: {str(e)}，无法切换账号")
+                    report("failed", f"启动浏览器失败: {e}", 100)
+                    return False
 
             page = self.controller.page
             if page is None:
-                print_error("Page 对象为 None，无法切换账号")
+                print_error("Page 对象仍为 None，无法切换账号")
+                report("failed", "无法获取 Page 对象", 100)
                 return False
 
             # 等待页面加载完成，添加异常处理
+            report("starting_browser", "等待公众平台首页加载…", 55)
             try:
                 await page.wait_for_load_state("networkidle", timeout=10000)
             except Exception as e:
                 print_warning(f"等待页面加载状态失败: {str(e)}，继续尝试切换账号...")
 
             # 点击账号信息区域打开账号面板
+            report("clicking", "打开账号面板…", 65)
             account_info = page.locator(".weui-desktop-account__info")
             if await account_info.count() > 0:
                 await account_info.click()
@@ -192,6 +227,7 @@ class Wx:
                             print(f"当前一共有{account_count}个可切换账号")
                             import random
                             if account_count > 0:
+                                report("clicking", f"找到 {account_count} 个可切换账号，正在选择…", 75)
                                 # 点击第一个可切换的账号
                                 random_index = random.randint(0, account_count - 1)
                                 await asyncio.sleep(1)
@@ -225,36 +261,38 @@ class Wx:
                                     pass
                                 # 添加延迟，避免 Playwright memoryview 缓冲区问题
                                 await asyncio.sleep(0.5)
-                                # 注意：切换成功后不立即关闭浏览器，让新的session有时间稳定
-                                # await self.Close()  # 移除此行，避免过早关闭导致session失效
                                 sys_notice(f"账号切换成功\n- 账号名称: {account_name} \n- 账号ID: {account_id} \n - Token: {token} \n- 过期时间: {exp_time}", str(cfg.get("server.code_title","WeRss账号切换成功")))
+                                report("done", f"切换成功：{account_name}", 100)
                                 return True
                             else:
                                 print_warning("没有找到可切换的账号")
+                                report("failed", "没有可切换的账号（只剩当前登录账号）", 100)
                                 return False
                         except Exception as e:
                             print_error(f"切换账号时发生错误: {str(e)}")
+                            report("failed", f"切换错误: {e}", 100)
                             return False
                     else:
                         print_warning("未找到切换账号按钮")
+                        report("failed", "未找到切换账号按钮（公众平台改版？）", 100)
                         return False
                 else:
                     print_warning("账号面板未打开")
+                    report("failed", "账号面板未打开", 100)
                     return False
             else:
                 print_warning("未找到账号信息区域")
-                raise Exception("未找到账号信息区域，无法切换账号")
+                # 选择器 miss：兜底触发 QR 流（仅本地接口返回 ok=False，让前端引导重新扫码）
+                report("failed", "未找到账号信息区域，请重新扫码授权", 100)
                 return False
 
         except Exception as e:
             print_error(f"切换账号时发生错误: {str(e)}")
+            report("failed", f"切换错误: {e}", 100)
             return False
         finally:
             # 恢复任务队列
             try:
-                  # 切换失败时清理资源
-                self.cleanup_resources()
-                await self.Close()
                 from core.queue import TaskQueue, ContentTaskQueue
                 print_info(f"准备恢复队列: 主队列={main_queue_was_running}, 内容队列={content_queue_was_running}")
                 if main_queue_was_running:
@@ -265,9 +303,8 @@ class Wx:
                     print_info("恢复内容任务队列...")
                     ContentTaskQueue.run_task_background()
                     print_success("内容任务队列已恢复")
-                # 注意：不再无条件清理资源，只在失败时清理（已在except块中处理）
             except Exception as e:
-                print_error(f"恢复队列失败: {e}") 
+                print_error(f"恢复队列失败: {e}")
     def GetCode(self,CallBack=None,Notice=None):
         self.Notice=Notice
         if  self.check_lock():

--- a/jobs/failauth.py
+++ b/jobs/failauth.py
@@ -1,4 +1,4 @@
-from core.print import print_warning
+from core.print import print_warning, print_info
 from driver.base import WX_API
 from core.config import cfg
 from jobs.notice import sys_notice
@@ -6,22 +6,59 @@ from driver.success import Success
 from tools.base64_tools import image_to_base64
 import time
 
-def send_wx_code(title:str="",url:str=""):
-    if cfg.get("server.send_code",False):
-        WX_API.GetCode(Notice=CallBackNotice,CallBack=Success)
-    pass
-def CallBackNotice(data=None,ext_data=None):
-        if data is not None:
-            print_warning(data)
-            return 
-        img_path=WX_API.QRcode()['code']
-        rss_domain=str(cfg.get("rss.base_url",""))
-        url=rss_domain+str(img_path)
-        url=image_to_base64("./static/wx_qrcode.png")
-        text=f"- 服务名：{cfg.get('server.name','')}\n"
-        text+=f"- 发送时间： {time.strftime('%Y-%m-%d %H:%M:%S',time.localtime(time.time()))}"
-        if WX_API.GetHasCode():
-            text+=f"![描述]({url})"
-            # text+=f"<img src='{url}' width='100' height='100'/>"
-            text+=f"\n- 请使用微信扫描二维码进行授权"
-        sys_notice(text, str(cfg.get("server.code_title","WeRss授权过期,扫码授权")))
+
+def send_wx_code(title: str = "", url: str = ""):
+    """发送微信授权过期通知
+
+    始终发送过期通知。当 send_code=True 时，尝试获取二维码并附带在通知中；
+    当 send_code=False 时，只发送文字通知（不含二维码）。
+    """
+    # 始终发送过期通知（不依赖 send_code 配置）
+    text = f"- 服务名：{cfg.get('server.name', '')}\n"
+    text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}\n"
+    if title:
+        text += f"- 原因：{title}\n"
+
+    notice_title = str(cfg.get("server.code_title", "WeRss授权过期,扫码授权"))
+
+    if cfg.get("server.send_code", False):
+        # send_code=True: 尝试获取二维码，通过回调发送含二维码的通知
+        WX_API.GetCode(Notice=CallBackNotice, CallBack=Success)
+    else:
+        # send_code=False: 直接发送不含二维码的文字通知
+        text += "- 请手动访问系统进行扫码登录"
+        try:
+            sys_notice(text=text, title=notice_title)
+            print_info(f"已发送授权过期通知(无二维码): {notice_title}")
+        except Exception as e:
+            print_warning(f"发送授权过期通知失败: {e}")
+
+
+def CallBackNotice(data=None, ext_data=None):
+    """获取二维码过程中的回调通知"""
+    if data is not None:
+        print_warning(data)
+        # 获取二维码出错时，发送不含二维码的通知提醒用户手动登录
+        text = f"- 服务名：{cfg.get('server.name', '')}\n"
+        text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}\n"
+        text += f"- 获取二维码失败：{data}\n"
+        text += "- 请手动访问系统进行扫码登录"
+        try:
+            sys_notice(
+                text=text,
+                title=str(cfg.get("server.code_title", "WeRss授权过期"))
+            )
+        except Exception as e:
+            print_warning(f"发送二维码获取失败通知失败: {e}")
+        return
+
+    img_path = WX_API.QRcode()['code']
+    rss_domain = str(cfg.get("rss.base_url", ""))
+    url = rss_domain + str(img_path)
+    url = image_to_base64("./static/wx_qrcode.png")
+    text = f"- 服务名：{cfg.get('server.name', '')}\n"
+    text += f"- 发送时间：{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))}"
+    if WX_API.GetHasCode():
+        text += f"![描述]({url})"
+        text += f"\n- 请使用微信扫描二维码进行授权"
+    sys_notice(text, str(cfg.get("server.code_title", "WeRss授权过期,扫码授权")))

--- a/jobs/fetch_no_article.py
+++ b/jobs/fetch_no_article.py
@@ -53,6 +53,9 @@ def fetch_articles_without_content():
                         print_error(f"获取文章 {article.title} 内容已被发布者删除")
                     else:
                         print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:8001/views/article/{article.id}")
+                        # 成功获取内容后，恢复原始状态（通常为 ACTIVE），释放 FETCHING 锁
+                        article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
+                        session.commit()
                 else:
                     # 获取失败，恢复状态以便后续重试
                     article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)

--- a/jobs/fetch_no_article.py
+++ b/jobs/fetch_no_article.py
@@ -52,7 +52,7 @@ def fetch_articles_without_content():
                     if article.status == DATA_STATUS.DELETED:
                         print_error(f"获取文章 {article.title} 内容已被发布者删除")
                     else:
-                        print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:8001/views/article/{article.id}")
+                        print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:{cfg.get('port', 8001)}/views/article/{article.id}")
                         # 成功获取内容后，恢复原始状态（通常为 ACTIVE），释放 FETCHING 锁
                         article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
                         session.commit()

--- a/jobs/fetch_no_article.py
+++ b/jobs/fetch_no_article.py
@@ -3,8 +3,90 @@ import core.db as db
 from core.config import cfg
 from core.wait import Wait
 from core.print import print_success,print_error,print_warning
-from core.article_content import build_article_url, sync_article_content
+from core.article_content import (
+    build_article_url,
+    mark_article_fetch_failed,
+    sync_article_content,
+)
 DB=db.Db(tag="内容修正")
+
+
+def recover_stale_fetching_articles(session, now_millis: int = None) -> int:
+    """Release expired or legacy FETCHING locks and account for the failure."""
+    import time
+    from sqlalchemy import case, func, or_
+
+    now_millis = now_millis or int(time.time() * 1000)
+    stale_seconds = int(cfg.get("gather.content_fetch_stale_timeout", 300) or 300)
+    stale_before = now_millis - stale_seconds * 1000
+    max_failures = int(cfg.get("gather.content_max_failures", 3) or 3)
+    next_fail_count = func.coalesce(Article.fix_fail_count, 0) + 1
+
+    recovered = session.query(Article).filter(
+        Article.status == DATA_STATUS.FETCHING,
+        or_(
+            Article.fetch_started_at.is_(None),
+            Article.fetch_started_at < stale_before,
+        ),
+    ).update(
+        {
+            Article.status: case(
+                (next_fail_count >= max_failures, DATA_STATUS.FAILED),
+                else_=DATA_STATUS.ACTIVE,
+            ),
+            Article.fix_fail_count: next_fail_count,
+            Article.fetch_started_at: None,
+        },
+        synchronize_session=False,
+    )
+    session.commit()
+    if recovered:
+        print_warning(f"已恢复 {recovered} 篇陈旧 FETCHING 文章")
+    return recovered
+
+
+def claim_next_article(session, excluded_ids=None, now_millis: int = None):
+    """Atomically claim one article immediately before it is fetched."""
+    import time
+    from sqlalchemy import or_
+
+    excluded_ids = excluded_ids or set()
+    max_failures = int(cfg.get("gather.content_max_failures", 3) or 3)
+
+    while True:
+        query = session.query(Article).filter(
+            Article.has_content == 0,
+            Article.status != DATA_STATUS.FETCHING,
+            Article.status != DATA_STATUS.DELETED,
+            or_(Article.fix_fail_count.is_(None), Article.fix_fail_count < max_failures),
+        )
+        if excluded_ids:
+            query = query.filter(~Article.id.in_(excluded_ids))
+
+        candidate = query.order_by(Article.publish_time.desc()).first()
+        if candidate is None:
+            return None
+
+        claimed = session.query(Article).filter(
+            Article.id == candidate.id,
+            Article.has_content == 0,
+            Article.status == candidate.status,
+            or_(Article.fix_fail_count.is_(None), Article.fix_fail_count < max_failures),
+        ).update(
+            {
+                Article.status: DATA_STATUS.FETCHING,
+                Article.fetch_started_at: now_millis or int(time.time() * 1000),
+            },
+            synchronize_session=False,
+        )
+        session.commit()
+        if claimed:
+            session.expire_all()
+            return session.query(Article).filter(Article.id == candidate.id).first()
+
+        session.expire_all()
+
+
 def fetch_articles_without_content():
     """
     查询content为空的文章，调用微信内容提取方法获取内容并更新数据库
@@ -12,32 +94,20 @@ def fetch_articles_without_content():
     """
     session = DB.get_session()
     try:
-        # 查询content为空且未被锁定的文章
-        from sqlalchemy import or_
-        articles = session.query(Article).filter(
-            or_(Article.has_content==0),
-            Article.status != DATA_STATUS.FETCHING,  # 排除正在获取的文章
-            Article.status != DATA_STATUS.DELETED,  # 已删除文章不再参与自动补抓
-            or_(Article.fix_fail_count.is_(None), Article.fix_fail_count < 3)  # 排除失败3次及以上的文章
-        ).order_by(Article.publish_time.desc()).limit(10).all()
-        
-        if not articles:
-            print_warning("暂无需要获取内容的文章")
-            return
+        recover_stale_fetching_articles(session)
+        batch_size = int(cfg.get("gather.content_batch_size", 5) or 5)
+        processed_ids = set()
 
-        original_status_map = {
-            article.id: article.status for article in articles
-        }
-        
-        # 锁定文章状态，防止其他节点获取
-        article_ids = [a.id for a in articles]
-        session.query(Article).filter(Article.id.in_(article_ids)).update(
-            {Article.status: DATA_STATUS.FETCHING},
-            synchronize_session=False
-        )
-        session.commit()
-        
-        for article in articles:
+        for _ in range(batch_size):
+            article = claim_next_article(session, excluded_ids=processed_ids)
+            if article is None:
+                if not processed_ids:
+                    print_warning("暂无需要获取内容的文章")
+                break
+
+            processed_ids.add(article.id)
+            article_id = article.id
+            article_title = article.title
             try:
                 url = build_article_url(article)
                 print(f"正在处理文章: {article.title}, URL: {url}")
@@ -53,20 +123,15 @@ def fetch_articles_without_content():
                         print_error(f"获取文章 {article.title} 内容已被发布者删除")
                     else:
                         print_success(f"成功更新文章 {article.title} 的内容, mode={fetch_mode} url: http://127.0.0.1:{cfg.get('port', 8001)}/views/article/{article.id}")
-                        # 成功获取内容后，恢复原始状态（通常为 ACTIVE），释放 FETCHING 锁
-                        article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
-                        session.commit()
                 else:
-                    # 获取失败，恢复状态以便后续重试
-                    article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
-                    session.commit()
                     print_error(f"获取文章 {article.title} 内容失败, mode={fetch_mode}")
                 Wait(min=5,max=10,tips=f"修正 {article.title}... 完成")
             except Exception as e:
-                # 单篇文章处理失败，恢复状态
-                article.status = original_status_map.get(article.id, DATA_STATUS.ACTIVE)
-                session.commit()
-                print_error(f"处理文章 {article.title} 时发生错误: {e}")
+                session.rollback()
+                article = session.query(Article).filter(Article.id == article_id).first()
+                if article and article.status == DATA_STATUS.FETCHING:
+                    mark_article_fetch_failed(session, article, str(e))
+                print_error(f"处理文章 {article_title} 时发生错误: {e}")
     except Exception as e:
         print_error(f"处理过程中发生错误: {e}")
         raise  # 重新抛出异常，让队列记录错误

--- a/jobs/mps.py
+++ b/jobs/mps.py
@@ -232,7 +232,7 @@ def add_job(feeds:list[Feed]=None,task:MessageTask=None,isTest=False):
     pass
 import json
 def get_feeds(task:MessageTask=None):
-     mps = json.loads(task.mps_id)
+     mps = json.loads(task.mps_id) if task.mps_id else []
      ids=",".join([item["id"]for item in mps])
      mps=wx_db.get_mps_list(ids)
      if len(mps)==0:

--- a/jobs/webhook.py
+++ b/jobs/webhook.py
@@ -196,7 +196,8 @@ def call_webhook(hook: MessageWebHook, is_test: bool = False) -> str:
             hook.task.web_hook_url,
             data=payload,
             headers=headers,
-            cookies=cookies
+            cookies=cookies,
+            timeout=30
         )
         response.raise_for_status()
         return "Webhook调用成功"

--- a/tests/test_article_refresh_task.py
+++ b/tests/test_article_refresh_task.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.config import cfg
+
+cfg.config["db"] = "sqlite:////tmp/werss-refresh-task-import.db"
+
+from apis import article as article_api
+from core.models.article import Article
+from core.models.base import Base, DATA_STATUS
+
+
+class ArticleRefreshTaskTest(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+        self.session = self.Session()
+        self.session.add(
+            Article(
+                id="article-id",
+                title="article",
+                url="https://mp.weixin.qq.com/s/article-id",
+                content="",
+                has_content=0,
+                status=DATA_STATUS.ACTIVE,
+            )
+        )
+        self.session.commit()
+        article_api._refresh_tasks.clear()
+
+    def tearDown(self):
+        self.session.close()
+        self.engine.dispose()
+
+    def test_manual_refresh_uses_shared_sync_and_reports_timeout(self):
+        with (
+            patch.object(article_api.DB, "get_session", return_value=self.session),
+            patch.object(
+                article_api,
+                "sync_article_content",
+                return_value=(False, "timeout"),
+            ) as sync_content,
+        ):
+            article_api._run_refresh_article_task("task-id", "article-id")
+
+        sync_content.assert_called_once()
+        self.assertTrue(sync_content.call_args.kwargs["force"])
+        task = article_api._refresh_tasks["task-id"]
+        self.assertEqual(task["status"], "failed")
+        self.assertIn("timeout", task["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_content_fetch_queue.py
+++ b/tests/test_content_fetch_queue.py
@@ -1,0 +1,217 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import sessionmaker
+
+from core.config import cfg
+
+cfg.config["db"] = "sqlite:////tmp/werss-content-queue-import.db"
+
+from core import article_content
+from core.models.article import Article
+from core.models.base import Base, DATA_STATUS
+
+module_spec = importlib.util.spec_from_file_location(
+    "fetch_no_article_under_test",
+    Path(__file__).parents[1] / "jobs" / "fetch_no_article.py",
+)
+fetch_no_article = importlib.util.module_from_spec(module_spec)
+module_spec.loader.exec_module(fetch_no_article)
+
+
+def config_value(key, default=None):
+    values = {
+        "gather.content_batch_size": 2,
+        "gather.content_fetch_stale_timeout": 300,
+        "gather.content_max_failures": 3,
+        "gather.content_mode": "web",
+    }
+    return values.get(key, default)
+
+
+class ContentFetchQueueTest(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+        self.session = self.Session()
+        self.config_patch = patch.object(cfg, "get", side_effect=config_value)
+        self.config_patch.start()
+
+    def tearDown(self):
+        self.config_patch.stop()
+        self.session.close()
+        self.engine.dispose()
+
+    def add_article(self, article_id, **values):
+        defaults = {
+            "id": article_id,
+            "title": article_id,
+            "url": f"https://mp.weixin.qq.com/s/{article_id}",
+            "publish_time": 1,
+            "status": DATA_STATUS.ACTIVE,
+            "has_content": 0,
+            "fix_fail_count": 0,
+        }
+        defaults.update(values)
+        article = Article(**defaults)
+        self.session.add(article)
+        self.session.commit()
+        return article
+
+    def test_recovers_legacy_and_stale_locks_but_not_fresh_lock(self):
+        now_millis = 1_000_000
+        self.add_article(
+            "legacy",
+            status=DATA_STATUS.FETCHING,
+            fetch_started_at=None,
+        )
+        self.add_article(
+            "stale",
+            status=DATA_STATUS.FETCHING,
+            fetch_started_at=600_000,
+        )
+        self.add_article(
+            "fresh",
+            status=DATA_STATUS.FETCHING,
+            fetch_started_at=900_000,
+        )
+
+        recovered = fetch_no_article.recover_stale_fetching_articles(
+            self.session,
+            now_millis=now_millis,
+        )
+
+        self.assertEqual(recovered, 2)
+        for article_id in ("legacy", "stale"):
+            article = self.session.get(Article, article_id)
+            self.assertEqual(article.status, DATA_STATUS.ACTIVE)
+            self.assertEqual(article.fix_fail_count, 1)
+            self.assertIsNone(article.fetch_started_at)
+        fresh = self.session.get(Article, "fresh")
+        self.assertEqual(fresh.status, DATA_STATUS.FETCHING)
+        self.assertEqual(fresh.fix_fail_count, 0)
+        self.assertEqual(fresh.fetch_started_at, 900_000)
+
+    def test_claims_only_one_article(self):
+        self.add_article("older", publish_time=1)
+        self.add_article("newer", publish_time=2)
+
+        claimed = fetch_no_article.claim_next_article(
+            self.session,
+            now_millis=123_000,
+        )
+
+        self.assertEqual(claimed.id, "newer")
+        self.assertEqual(claimed.status, DATA_STATUS.FETCHING)
+        self.assertEqual(claimed.fetch_started_at, 123_000)
+        self.assertEqual(self.session.get(Article, "older").status, DATA_STATUS.ACTIVE)
+
+    def test_legacy_table_gets_fetch_started_at_column(self):
+        engine = create_engine("sqlite:///:memory:")
+        with engine.begin() as connection:
+            connection.execute(text("CREATE TABLE articles (id VARCHAR(255) PRIMARY KEY)"))
+
+        database = fetch_no_article.db.Db.__new__(fetch_no_article.db.Db)
+        database.engine = engine
+        database.tag = "test"
+        database.ensure_article_columns()
+
+        columns = {column["name"] for column in inspect(engine).get_columns("articles")}
+        self.assertIn("fetch_started_at", columns)
+        engine.dispose()
+
+    def test_empty_fetch_increments_failure_and_releases_lock(self):
+        article = self.add_article(
+            "empty",
+            status=DATA_STATUS.FETCHING,
+            fetch_started_at=123_000,
+        )
+
+        with patch.object(
+            article_content,
+            "fetch_article_content",
+            return_value=("", "web", ""),
+        ):
+            updated, mode = article_content.sync_article_content(
+                self.session,
+                article,
+            )
+
+        self.assertFalse(updated)
+        self.assertEqual(mode, "web")
+        self.assertEqual(article.fix_fail_count, 1)
+        self.assertEqual(article.status, DATA_STATUS.ACTIVE)
+        self.assertIsNone(article.fetch_started_at)
+
+    def test_failed_forced_refresh_preserves_existing_content(self):
+        article = self.add_article(
+            "existing",
+            content="<p>existing body</p>",
+            has_content=1,
+        )
+
+        with patch.object(
+            article_content,
+            "fetch_article_content",
+            return_value=("", "web", ""),
+        ):
+            updated, _ = article_content.sync_article_content(
+                self.session,
+                article,
+                force=True,
+            )
+
+        self.assertFalse(updated)
+        self.assertEqual(article.content, "<p>existing body</p>")
+        self.assertEqual(article.has_content, 1)
+        self.assertEqual(article.status, DATA_STATUS.ACTIVE)
+
+    def test_api_only_mode_does_not_fall_back_to_web(self):
+        with (
+            patch.object(article_content, "_fetch_with_api", return_value=("", {})),
+            patch.object(article_content, "_fetch_with_web") as web_fetch,
+        ):
+            content, mode, _ = article_content._fetch_article_content_unbounded(
+                "https://example.com/article",
+                preferred_mode="api",
+                allow_fallback=False,
+            )
+
+        self.assertEqual(content, "")
+        self.assertEqual(mode, "api")
+        web_fetch.assert_not_called()
+
+    def test_failed_article_does_not_prevent_next_batch_item(self):
+        self.add_article("first", publish_time=2)
+        self.add_article("second", publish_time=1)
+        processed_ids = []
+
+        def fail_fetch(session, article, preferred_mode=None):
+            processed_ids.append(article.id)
+            article.status = DATA_STATUS.ACTIVE
+            article.fetch_started_at = None
+            article.fix_fail_count += 1
+            session.commit()
+            return False, "web"
+
+        with (
+            patch.object(
+                fetch_no_article,
+                "DB",
+                SimpleNamespace(get_session=self.Session),
+            ),
+            patch.object(fetch_no_article, "sync_article_content", side_effect=fail_fetch),
+            patch.object(fetch_no_article, "Wait"),
+        ):
+            fetch_no_article.fetch_articles_without_content()
+
+        self.assertEqual(processed_ids, ["first", "second"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_content_fetch_queue.py
+++ b/tests/test_content_fetch_queue.py
@@ -33,6 +33,13 @@ def config_value(key, default=None):
     return values.get(key, default)
 
 
+WECHAT_SHELL = """
+<p>知道了 取消 允许</p>
+<p>微信扫一扫可打开此内容，使用完整服务</p>
+<p>视频 小程序 赞 在看 分享 留言 收藏 听过</p>
+"""
+
+
 class ContentFetchQueueTest(unittest.TestCase):
     def setUp(self):
         self.engine = create_engine("sqlite:///:memory:")
@@ -170,6 +177,88 @@ class ContentFetchQueueTest(unittest.TestCase):
         self.assertEqual(article.content, "<p>existing body</p>")
         self.assertEqual(article.has_content, 1)
         self.assertEqual(article.status, DATA_STATUS.ACTIVE)
+
+    def test_failed_refresh_does_not_preserve_wechat_shell_as_content(self):
+        article = self.add_article(
+            "shell",
+            content=WECHAT_SHELL,
+            has_content=1,
+        )
+
+        with patch.object(
+            article_content,
+            "fetch_article_content",
+            return_value=("", "api", ""),
+        ):
+            updated, _ = article_content.sync_article_content(
+                self.session,
+                article,
+                force=True,
+            )
+
+        self.assertFalse(updated)
+        self.assertEqual(article.has_content, 0)
+        self.assertEqual(article.status, DATA_STATUS.ACTIVE)
+
+    def test_wechat_shell_is_not_usable_article_content(self):
+        self.assertFalse(article_content.is_usable_article_content(WECHAT_SHELL))
+        self.assertTrue(
+            article_content.is_usable_article_content(
+                '<div id="js_content"><p>real article body</p></div>'
+            )
+        )
+
+    def test_api_fetch_extracts_only_article_container(self):
+        response_html = """
+        <html><body>
+          <div>page chrome</div>
+          <div id="js_content"><p>article body</p></div>
+        </body></html>
+        """
+        with patch(
+            "core.wx.model.api.MpsApi.content_extract",
+            return_value=response_html,
+        ):
+            content, metadata = article_content._fetch_with_api(
+                "https://example.com/article"
+            )
+
+        self.assertIn("article body", content)
+        self.assertNotIn("page chrome", content)
+        self.assertEqual(metadata, {})
+
+    def test_api_fetch_rejects_page_without_article_container(self):
+        with patch(
+            "core.wx.model.api.MpsApi.content_extract",
+            return_value="<html><body>未知错误，请稍后再试</body></html>",
+        ):
+            content, _ = article_content._fetch_with_api(
+                "https://example.com/article"
+            )
+
+        self.assertEqual(content, "")
+
+    def test_unusable_web_result_falls_back_to_api(self):
+        with (
+            patch.object(
+                article_content,
+                "_fetch_with_web",
+                return_value=(WECHAT_SHELL, {}),
+            ),
+            patch.object(
+                article_content,
+                "_fetch_with_api",
+                return_value=("<p>real article body</p>", {}),
+            ),
+        ):
+            content, mode, _ = article_content._fetch_article_content_unbounded(
+                "https://example.com/article",
+                preferred_mode="web",
+                allow_fallback=True,
+            )
+
+        self.assertEqual(content, "<p>real article body</p>")
+        self.assertEqual(mode, "api")
 
     def test_api_only_mode_does_not_fall_back_to_web(self):
         with (

--- a/tests/test_process_timeout.py
+++ b/tests/test_process_timeout.py
@@ -1,0 +1,46 @@
+import time
+import unittest
+
+from core.process_timeout import (
+    ProcessExecutionError,
+    ProcessExecutionTimeout,
+    run_in_process,
+)
+
+
+def return_value(value):
+    return value
+
+
+def sleep_for(seconds):
+    time.sleep(seconds)
+
+
+def raise_remote_error():
+    raise ValueError("remote failure")
+
+
+class ProcessTimeoutTest(unittest.TestCase):
+    def test_returns_successful_result(self):
+        self.assertEqual(run_in_process(return_value, "ok", timeout=2), "ok")
+
+    def test_terminates_hung_process(self):
+        started_at = time.monotonic()
+
+        with self.assertRaises(ProcessExecutionTimeout):
+            run_in_process(
+                sleep_for,
+                10,
+                timeout=0.2,
+                cleanup_timeout=0.5,
+            )
+
+        self.assertLess(time.monotonic() - started_at, 2)
+
+    def test_surfaces_remote_exception(self):
+        with self.assertRaisesRegex(ProcessExecutionError, "remote failure"):
+            run_in_process(raise_remote_error, timeout=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/mdtools/pdf.py
+++ b/tools/mdtools/pdf.py
@@ -44,11 +44,13 @@
 """
 import asyncio
 import sys
+import os
 import atexit
 from typing import Optional, Dict, Any
 from pathlib import Path
 from playwright.async_api import async_playwright, Browser, Page, BrowserContext
 import logging
+from driver.chrome_path import get_chrome_executable_path
 
 # Windows 平台需要使用 ProactorEventLoop 以支持子进程
 # Playwright 需要启动浏览器子进程，必须使用 ProactorEventLoop
@@ -96,9 +98,17 @@ class WebToPDFConverter:
     async def _ensure_browser(self) -> Browser:
         """确保浏览器已启动"""
         if self._browser is None:
+            # ===== 本地 Chrome 支持（可选，避免强制 playwright install 下载浏览器）=====
+            # 仅当通过环境变量 CHROME_EXECUTABLE_PATH 指定（或自动发现到本机标准 Chromium 浏览器）时启用。
+            CHROME_PATH = get_chrome_executable_path()
+            if CHROME_PATH:
+                self.browser_type = "chromium"
             self._playwright = await async_playwright().start()
+            launch_kwargs = {"headless": self.headless}
+            if self.browser_type == "chromium" and CHROME_PATH:
+                launch_kwargs["executable_path"] = CHROME_PATH
             if self.browser_type == "chromium":
-                self._browser = await self._playwright.chromium.launch(headless=self.headless)
+                self._browser = await self._playwright.chromium.launch(**launch_kwargs)
             elif self.browser_type == "firefox":
                 self._browser = await self._playwright.firefox.launch(headless=self.headless)
             elif self.browser_type == "webkit":


### PR DESCRIPTION
Fixes #440\n\n## What changed\n- Defer feed cursor advancement until the requested list crawl completes.\n- Keep the cursor unchanged for WeChat rate limiting, request timeouts, invalid sessions, and other incomplete responses.\n- Apply the guard to Web, App, and API collectors.\n\n## Why\nThe previous code updated feeds.sync_time before receiving the list response. A rate-limited zero-result crawl could therefore permanently skip articles published in that interval.\n\n## Validation\n- Syntax-checked the four changed Python files in the deployed runtime.\n- Simulated rate-limit and complete empty-list responses: the former does not commit the cursor; the latter does.\n- Rebuilt the deployment and verified HTTP 200, zero container restarts, and unchanged SQLite counts.