### PR TITLE
fix(weread): use MP auth check in weread_mp mode

### DIFF
--- a/apis/test_weread.py
+++ b/apis/test_weread.py
@@ -29,19 +29,28 @@ class WereadConfigAPITest(unittest.TestCase):
         self.assertEqual(saved["vid"], "123")
         self.assertEqual(saved["ticket"], "ticket-value")
 
+    @patch("apis.weread.app_cfg.get")
     @patch("apis.weread._load_weread_data")
-    def test_status_reports_ticket_separately_from_notes_configuration(self, load):
+    def test_status_reports_mp_mode_without_requiring_ticket(self, load, config_get):
         load.return_value = {
             "cookie": "wr_vid=123; wr_skey=skey",
             "vid": "123",
             "ticket": "",
         }
+        values = {
+            "weread.cookie": "",
+            "weread.ticket": "",
+            "weread.vid": "",
+            "gather.model": "weread_mp",
+        }
+        config_get.side_effect = lambda key, default="": values.get(key, default)
 
         response = asyncio.run(get_weread_status(current_user={"id": "test"}))
 
         self.assertTrue(response["data"]["configured"])
-        self.assertFalse(response["data"]["mp_configured"])
+        self.assertTrue(response["data"]["mp_configured"])
         self.assertFalse(response["data"]["has_ticket"])
+        self.assertEqual(response["data"]["gather_model"], "weread_mp")
 
     @patch("apis.weread.app_cfg.get")
     @patch("apis.weread._load_weread_data", return_value={})
@@ -100,7 +109,7 @@ class WereadConfigAPITest(unittest.TestCase):
         save.assert_not_called()
 
     @patch("core.wx.model.weread_mp.MpsWereadMP")
-    def test_mp_connection_rejects_invalid_ticket(self, collector_class):
+    def test_mp_connection_reports_api_auth_error(self, collector_class):
         from core.wx.model.weread_mp import WereadMPAPIError
 
         collector = collector_class.return_value

--- a/apis/weread.py
+++ b/apis/weread.py
@@ -84,6 +84,7 @@ async def get_weread_status(current_user=Depends(get_current_user_or_ak)):
     ticket = config_ticket or data.get("ticket", "")
     vid = config_vid or data.get("vid", "")
     name = data.get("name", "")
+    gather_model = app_cfg.get("gather.model", "web") or "web"
 
     # 判断是否已配置
     has_cookie = bool(cookie and vid)
@@ -96,7 +97,8 @@ async def get_weread_status(current_user=Depends(get_current_user_or_ak)):
         "ticket": ticket,          # 完整 x-wr-ticket（如有）
         "has_cookie": bool(cookie),
         "has_ticket": bool(ticket),
-        "mp_configured": bool(cookie and ticket),
+        "mp_configured": bool(cookie),
+        "gather_model": gather_model,
         "managed_by_config": bool(config_cookie or config_ticket or config_vid),
         "cookie_managed_by_config": bool(config_cookie),
         "ticket_managed_by_config": bool(config_ticket),
@@ -199,7 +201,7 @@ async def test_weread_mp_connection(
     req: WereadMPTestRequest,
     current_user=Depends(get_current_user_or_ak),
 ):
-    """Use an existing MP feed to validate Cookie and x-wr-ticket together."""
+    """Use an existing MP feed to validate the configured WeRead credentials."""
     from core.db import DB
     from core.models.feed import Feed
     from core.wx.model.weread_mp import MpsWereadMP, WereadMPAPIError, parse_mp_articles

--- a/web_ui/src/views/WereadManagement.vue
+++ b/web_ui/src/views/WereadManagement.vue
@@ -8,7 +8,12 @@
         正在测试连接...
       </a-alert>
       <a-alert v-else-if="connectionStatus === 'success'" type="success">
-        连接成功！书架共 {{ bookCount }} 本书，用户 VID: {{ vid }}<span v-if="hasTicket">；公众号采集凭据已验证</span>
+        <template v-if="isWereadMp">
+          公众号采集连接成功，共检测到 {{ articleCount }} 篇文章
+        </template>
+        <template v-else>
+          连接成功！书架共 {{ bookCount }} 本书，用户 VID: {{ vid }}
+        </template>
       </a-alert>
       <a-alert v-else-if="connectionStatus === 'error'" type="error">
         连接失败：{{ errorMsg }}
@@ -27,10 +32,10 @@
             :disabled="cookieManagedByConfig"
           />
         </a-form-item>
-        <a-form-item label="x-wr-ticket（公众号采集）" field="ticket" extra="仅 weread_mp 模式需要：从 /web/mp/articles 请求的 Request Headers 复制">
+        <a-form-item label="x-wr-ticket（兼容旧版）" field="ticket" extra="当前版本通常可留空；仅旧版接口要求时填写">
           <a-input-password
             v-model="cookieForm.ticket"
-            placeholder="粘贴 x-wr-ticket；只采集书籍笔记时可留空"
+            placeholder="通常可留空；仅旧版接口要求时填写"
             allow-clear
             :disabled="ticketManagedByConfig"
           />
@@ -66,8 +71,8 @@
       </a-form>
 
       <!-- 书架区域 -->
-      <a-divider orientation="left">我的书架</a-divider>
-      <a-spin :loading="loadingBookshelf" tip="加载书架...">
+      <a-divider v-if="!isWereadMp" orientation="left">我的书架</a-divider>
+      <a-spin v-if="!isWereadMp" :loading="loadingBookshelf" tip="加载书架...">
         <div v-if="bookshelf.length === 0 && !loadingBookshelf" class="empty-bookshelf">
           <a-empty description="书架上暂无书籍，请先连接微信读书" />
         </div>
@@ -107,7 +112,7 @@
       </a-spin>
 
       <!-- 采集全部按钮 -->
-      <div style="margin-top: 16px" v-if="bookshelf.length > 0">
+      <div v-if="!isWereadMp && bookshelf.length > 0" style="margin-top: 16px">
         <a-button
           type="primary"
           @click="collectAllNotes"
@@ -148,13 +153,14 @@ import {
 // 状态
 const connectionStatus = ref<'idle' | 'loading' | 'success' | 'error'>('idle')
 const bookCount = ref(0)
+const articleCount = ref(0)
 const vid = ref('')
 const errorMsg = ref('')
 const saving = ref(false)
 const savingConfig = ref(false)
 const testing = ref(false)
 const hasConfig = ref(false)
-const hasTicket = ref(false)
+const isWereadMp = ref(false)
 const managedByConfig = ref(false)
 const cookieManagedByConfig = ref(false)
 const ticketManagedByConfig = ref(false)
@@ -201,7 +207,7 @@ async function loadStatus() {
   try {
     const data = await getWereadStatus() as any
     hasConfig.value = data.configured
-    hasTicket.value = data.has_ticket
+    isWereadMp.value = data.gather_model === 'weread_mp'
     managedByConfig.value = data.managed_by_config
     cookieManagedByConfig.value = data.cookie_managed_by_config
     ticketManagedByConfig.value = data.ticket_managed_by_config
@@ -240,9 +246,6 @@ async function saveCookie() {
     )
     Message.success('微信读书凭据保存成功')
     hasConfig.value = true
-    if (cookieForm.ticket || ticketManagedByConfig.value) {
-      hasTicket.value = true
-    }
     await testConnection()
   } catch (e: any) {
     Message.error(e?.message || '保存失败')
@@ -271,14 +274,16 @@ async function testConnection() {
   testing.value = true
   connectionStatus.value = 'loading'
   try {
-    const result = await testWereadConnection() as any
-    if (hasTicket.value) {
-      await testWereadMpConnection()
+    if (isWereadMp.value) {
+      const result = await testWereadMpConnection() as any
+      articleCount.value = result.article_count
+    } else {
+      const result = await testWereadConnection() as any
+      bookCount.value = result.book_count
+      vid.value = result.vid
+      await loadBookshelf()
     }
     connectionStatus.value = 'success'
-    bookCount.value = result.book_count
-    vid.value = result.vid
-    await loadBookshelf()
   } catch (e: any) {
     connectionStatus.value = 'error'
     errorMsg.value = typeof e === 'string' ? e : e?.message || '连接失败'
@@ -304,7 +309,6 @@ async function clearCookieHandler() {
     await clearWereadCookie()
     Message.success('Cookie 已清除')
     hasConfig.value = false
-    hasTicket.value = false
     connectionStatus.value = 'idle'
     bookshelf.value = []
     bookCount.value = 0


### PR DESCRIPTION
## Problem

The WeRead management page always validates the regular bookshelf endpoint first. In `weread_mp` deployments this can return 401 even when the MP article endpoint is working, causing the UI to incorrectly report that the Cookie has expired. The status UI also treats `x-wr-ticket` as required even though the current MP request path does not require it.

## Changes

- expose the active gather mode from the WeRead status API
- treat an MP configuration as configured when a Cookie is present, without requiring `x-wr-ticket`
- validate `/weread/mp/test` directly in `weread_mp` mode
- skip bookshelf loading and bookshelf-only controls in MP mode
- show the number of detected MP articles after a successful check
- clarify that `x-wr-ticket` is only retained for legacy compatibility
- add regression coverage for MP mode without a ticket

## Verification

- `python -m unittest apis.test_weread` (8 tests passed)
- `npm run build` (production build passed)
- `git diff --check`

## Configuration / migration

No migration or new configuration is required.